### PR TITLE
Remove entitlement entity on cancellation

### DIFF
--- a/src/main/java/org/folio/entitlement/service/stage/EntitlementFlowFinalizer.java
+++ b/src/main/java/org/folio/entitlement/service/stage/EntitlementFlowFinalizer.java
@@ -9,13 +9,14 @@ import org.folio.entitlement.domain.dto.Entitlement;
 import org.folio.entitlement.domain.dto.ExecutionStatus;
 import org.folio.entitlement.domain.model.EntitlementRequest;
 import org.folio.entitlement.service.EntitlementCrudService;
+import org.folio.flow.api.Cancellable;
 import org.folio.flow.api.StageContext;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class EntitlementFlowFinalizer extends AbstractFlowFinalizer {
+public class EntitlementFlowFinalizer extends AbstractFlowFinalizer implements Cancellable {
 
   private final EntitlementCrudService entitlementCrudService;
 
@@ -23,14 +24,25 @@ public class EntitlementFlowFinalizer extends AbstractFlowFinalizer {
   @Transactional
   public void execute(StageContext context) {
     super.execute(context);
-    var request = context.<EntitlementRequest>getFlowParameter(PARAM_REQUEST);
-    var applicationId = context.<String>getFlowParameter(PARAM_APP_ID);
-    var entitlement = new Entitlement().applicationId(applicationId).tenantId(request.getTenantId());
+    var entitlement = buildEntitlementFromContext(context);
     entitlementCrudService.save(entitlement);
+  }
+
+  @Override
+  @Transactional
+  public void cancel(StageContext context) {
+    var entitlement = buildEntitlementFromContext(context);
+    entitlementCrudService.delete(entitlement);
   }
 
   @Override
   protected ExecutionStatus getStatus() {
     return FINISHED;
+  }
+
+  private static Entitlement buildEntitlementFromContext(StageContext context) {
+    var request = context.<EntitlementRequest>getFlowParameter(PARAM_REQUEST);
+    var applicationId = context.<String>getFlowParameter(PARAM_APP_ID);
+    return new Entitlement().applicationId(applicationId).tenantId(request.getTenantId());
   }
 }

--- a/src/test/java/org/folio/entitlement/service/stage/EntitlementFlowFinalizerTest.java
+++ b/src/test/java/org/folio/entitlement/service/stage/EntitlementFlowFinalizerTest.java
@@ -10,6 +10,7 @@ import static org.folio.entitlement.support.TestConstants.APPLICATION_ID;
 import static org.folio.entitlement.support.TestConstants.FLOW_STAGE_ID;
 import static org.folio.entitlement.support.TestConstants.TENANT_ID;
 import static org.folio.entitlement.support.TestValues.entitlement;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,5 +70,16 @@ class EntitlementFlowFinalizerTest {
     var capturedValue = entitlementFlowEntityCaptor.getValue();
     assertThat(capturedValue.getStatus()).isEqualTo(FINISHED);
     verify(entitlementCrudService).save(entitlement(TENANT_ID, APPLICATION_ID));
+  }
+
+  @Test
+  void execute_cancel_positive() {
+    doNothing().when(entitlementCrudService).delete(entitlement(TENANT_ID, APPLICATION_ID));
+
+    var entitlementRequest = EntitlementRequest.builder().type(ENTITLE).tenantId(TENANT_ID).build();
+    var flowParameters = Map.of(PARAM_REQUEST, entitlementRequest, PARAM_APP_ID, APPLICATION_ID);
+    var stageContext = StageContext.of(FLOW_STAGE_ID, flowParameters, Map.of());
+
+    entitlementFlowFinalizer.cancel(stageContext);
   }
 }


### PR DESCRIPTION
## Purpose

Entitlement record is preserved if a flow was initially successful but then has been canceled due to an error in another flow which is installed at the same time. This leads to inconsistency and blocks from consecutive attempts to install the application. To fix the issue Entitlement record should be removed if the flow is canceled.

## Approach
* `EntitlementFlowFinalizer` implements cancellation by removing entitlement record from DB 

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
