### PR TITLE
[MGRENTITLE-26] mgr-tenant-entitlements - Keycloak resources creation issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,11 @@
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <semver4j.version>5.2.2</semver4j.version>
     <folio-spring-cql.version>8.0.0</folio-spring-cql.version>
-    <applications-poc-versions.version>1.0.0</applications-poc-versions.version>
+    <applications-poc-versions.version>1.1.0-SNAPSHOT</applications-poc-versions.version>
     <folio-integration-kong.version>1.1.0-SNAPSHOT</folio-integration-kong.version>
     <folio-security.version>1.2.0-SNAPSHOT</folio-security.version>
-    <folio-backend-testing.version>1.0.0</folio-backend-testing.version>
+    <folio-backend-common.version>1.1.0-SNAPSHOT</folio-backend-common.version>
+    <folio-backend-testing.version>1.1.0-SNAPSHOT</folio-backend-testing.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
     <folio-flow-engine.version>1.0.0</folio-flow-engine.version>
 
@@ -226,6 +227,12 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-security</artifactId>
       <version>${folio-security.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-backend-common</artifactId>
+      <version>${folio-backend-common.version}</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/org/folio/entitlement/it/FolioEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/FolioEntitlementIT.java
@@ -162,6 +162,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
     assertThat(keycloakTestClient.getAuthorizationScopes(TENANT_NAME)).containsExactlyElementsOf(ALL_HTTP_METHODS);
     assertThat(keycloakTestClient.getAuthorizationResources(TENANT_NAME))
       .containsExactly("/folio-module1/events", "/folio-module1/events/{id}");
+    assertEntitlementEvents(List.of(new EntitlementEvent(ENTITLE.name(), FOLIO_MODULE1_ID, TENANT_NAME, TENANT_ID)));
   }
 
   @Test
@@ -359,6 +360,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
     assertThat(keycloakTestClient.getAuthorizationScopes(TENANT_NAME)).containsExactlyElementsOf(ALL_HTTP_METHODS);
     assertThat(keycloakTestClient.getAuthorizationResources(TENANT_NAME)).containsExactly(
       "/folio-module1/events", "/folio-module1/events/{id}", "/folio-module2/events", "/folio-module2/events/{id}");
+    assertEntitlementEvents(List.of(new EntitlementEvent(ENTITLE.name(), FOLIO_MODULE1_ID, TENANT_NAME, TENANT_ID)));
   }
 
   @Test
@@ -395,6 +397,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
     assertThat(keycloakTestClient.getAuthorizationScopes(TENANT_NAME)).containsExactlyElementsOf(ALL_HTTP_METHODS);
     assertThat(keycloakTestClient.getAuthorizationResources(TENANT_NAME)).containsExactly(
       "/folio-module1/events", "/folio-module1/events/{id}", "/folio-module2/events", "/folio-module2/events/{id}");
+    assertEntitlementEvents(List.of(new EntitlementEvent(ENTITLE.name(), FOLIO_MODULE1_ID, TENANT_NAME, TENANT_ID)));
   }
 
   @Test

--- a/src/test/java/org/folio/entitlement/support/KafkaEventAssertions.java
+++ b/src/test/java/org/folio/entitlement/support/KafkaEventAssertions.java
@@ -35,7 +35,7 @@ public final class KafkaEventAssertions {
 
   public static void assertEntitlementEvents(List<EntitlementEvent> events) {
     var entitlementEvents = getRecordValues(() -> getEvents(entitlementTopic(), EntitlementEvent.class));
-    assertThat(entitlementEvents).containsExactlyInAnyOrderElementsOf(events);
+    assertThat(entitlementEvents).containsAll(events);
   }
 
   @SafeVarargs

--- a/src/test/resources/wiremock/mgr-applications/folio-app1/get-by-ids-query-full.json
+++ b/src/test/resources/wiremock/mgr-applications/folio-app1/get-by-ids-query-full.json
@@ -43,7 +43,12 @@
                     {
                       "methods": [ "POST" ],
                       "pathPattern": "/folio-module1/events",
-                      "permissionsRequired": [ "folio-module1.events.item.post" ]
+                      "permissionsRequired": [
+                        "folio-module1.events.item.post",
+                        "folio-module1.events.test-long-permissions-5bdfc09228a0c9425840edb25494fcd0.post",
+                        "folio-module1.events.test-long-permissions-1326380acd0a427bfbaa477638e05b38.post",
+                        "folio-module1.events.test-long-permissions-23fe4070ba90c9860cb0779462311a70.post"
+                      ]
                     },
                     {
                       "methods": [ "GET" ],
@@ -69,6 +74,21 @@
                     {
                       "methods": [ "GET", "DELETE" ],
                       "pathPattern": "/_/tenant/{id}"
+                    }
+                  ]
+                },
+                {
+                  "id": "_timer",
+                  "version": "1.0",
+                  "interfaceType": "system",
+                  "handlers": [
+                    {
+                      "methods": [
+                        "POST"
+                      ],
+                      "pathPattern": "/folio-module1/events",
+                      "unit": "day",
+                      "delay": "5"
                     }
                   ]
                 }

--- a/src/test/resources/wiremock/mgr-applications/folio-app1/get.json
+++ b/src/test/resources/wiremock/mgr-applications/folio-app1/get.json
@@ -36,7 +36,12 @@
                 {
                   "methods": [ "POST" ],
                   "pathPattern": "/folio-module1/events",
-                  "permissionsRequired": [ "folio-module1.events.item.post" ]
+                  "permissionsRequired": [
+                    "folio-module1.events.item.post",
+                    "folio-module1.events.test-long-permissions-5bdfc09228a0c9425840edb25494fcd0.post",
+                    "folio-module1.events.test-long-permissions-1326380acd0a427bfbaa477638e05b38.post",
+                    "folio-module1.events.test-long-permissions-23fe4070ba90c9860cb0779462311a70.post"
+                  ]
                 },
                 {
                   "methods": [ "GET" ],
@@ -62,6 +67,21 @@
                 {
                   "methods": [ "GET", "DELETE" ],
                   "pathPattern": "/_/tenant/{id}"
+                }
+              ]
+            },
+            {
+              "id": "_timer",
+              "version": "1.0",
+              "interfaceType": "system",
+              "handlers": [
+                {
+                  "methods": [
+                    "POST"
+                  ],
+                  "pathPattern": "/folio-module1/events",
+                  "unit": "day",
+                  "delay": "5"
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
Keycloak resource creation fails if:
- folio_permissions attribute value is longer than 255 symbols
- an endpoint has additional handler in system interfaces (such as _timer)

JIRA: https://issues.folio.org/browse/MGRENTITLE-26

## Approach
- Remove logic to exclude system interfaces in KeycloakService as it filters out handlers by name that are registered in _timer, instead call a mapper with **excludeSystemInterfaces=true**
- Improve error handling of Keycloak resources/scopes creation
- Update test stubs to reproduce the known issues
- Add dependency on folio-backend-common

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
