### PR TITLE
MGRENTITLE-31 Fix module dependency graph creation

### DIFF
--- a/src/test/java/org/folio/entitlement/utils/ModuleInstallationGraphTest.java
+++ b/src/test/java/org/folio/entitlement/utils/ModuleInstallationGraphTest.java
@@ -74,6 +74,14 @@ class ModuleInstallationGraphTest {
           module("m4", List.of("m4-int"), List.of("m3-int"))),
         List.of(Set.of("m2"), Set.of("m1", "m3"), Set.of("m4"))),
 
+      arguments("Dependent modules (m2 <- (m1, m3) <- m4(depends on m3 and m2))",
+        appDescriptor(
+          module("m1", List.of("m1-i1"), List.of("m2-int")),
+          module("m2", List.of("m2-int")),
+          module("m3", List.of("m3-int"), List.of("m2-int")),
+          module("m4", List.of("m4-int"), List.of("m2-int", "m3-int"))),
+        List.of(Set.of("m2"), Set.of("m1", "m3"), Set.of("m4"))),
+
       arguments("Dependent modules (m1 <- m4, m2 <- m3)",
         appDescriptor(
           module("m1", List.of("m1-int")),


### PR DESCRIPTION
## Purpose

Fixes an issue in module dependency tree algorithm, where the module with multiple required interfaces was treated by only the first match instead of checking all required interfaces.

## Approach

- Fix module installation graph creation
- Add unit test case to cover this issue

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
