### PR TITLE
APPPOCTOOL-7 Fix URL for wiremock container for EntitlementRoutesIT

### DIFF
--- a/src/test/java/org/folio/entitlement/it/EntitlementRoutesIT.java
+++ b/src/test/java/org/folio/entitlement/it/EntitlementRoutesIT.java
@@ -20,6 +20,8 @@ import static org.folio.entitlement.support.TestUtils.readString;
 import static org.folio.entitlement.support.TestValues.entitlementRequest;
 import static org.folio.entitlement.support.extensions.impl.KongGatewayExtension.KONG_GATEWAY_URL_PROPERTY;
 import static org.folio.test.TestConstants.OKAPI_AUTH_TOKEN;
+import static org.folio.test.extensions.impl.WireMockExtension.WM_DOCKER_PORT;
+import static org.folio.test.extensions.impl.WireMockExtension.WM_NETWORK_ALIAS;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpMethod.DELETE;
@@ -88,7 +90,7 @@ class EntitlementRoutesIT extends BaseIntegrationTest {
   static void beforeAll(@Autowired KongAdminClient kongTestAdminClient,
     @Autowired KongAdminClient kongAdminClient, @Autowired MockMvc mockMvc) {
     fakeKafkaConsumer.registerTopic(entitlementTopic(), EntitlementEvent.class);
-    var wiremockUrl = "http://host.testcontainers.internal:" + wmAdminClient.getWireMockPort();
+    var wiremockUrl = String.format("http://%s:%s", WM_NETWORK_ALIAS, WM_DOCKER_PORT);
     kongTestAdminClient.upsertService(ROUTES_MODULE1_ID, new Service().url(wiremockUrl + "/m1"));
     kongTestAdminClient.upsertService(ROUTES_MODULE2_ID, new Service().url(wiremockUrl + "/m2"));
 

--- a/src/test/java/org/folio/entitlement/it/FolioEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/FolioEntitlementIT.java
@@ -272,7 +272,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], cause: request timed out")));
+          + "\\[method: POST, uri: http://.+:\\d+/folio-module2/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
 
@@ -315,7 +315,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], cause: request timed out")));
+          + "\\[method: POST, uri: http://.+:\\d+/folio-module2/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
 
@@ -354,7 +354,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], cause: request timed out")));
+          + "\\[method: POST, uri: http://.+:\\d+/folio-module2/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
     assertThat(keycloakTestClient.getAuthorizationScopes(TENANT_NAME)).containsExactlyElementsOf(ALL_HTTP_METHODS);
@@ -390,7 +390,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[IOException] Failed to perform request "
-          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], "
+          + "\\[method: POST, uri: http://.+:\\d+/folio-module2/_/tenant], "
           + "cause: HTTP/1.1 header parser received no bytes")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());

--- a/src/test/java/org/folio/entitlement/it/FolioEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/FolioEntitlementIT.java
@@ -272,7 +272,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-          + "\\[method: POST, uri: http://localhost:\\d+/folio-module2/_/tenant], cause: request timed out")));
+          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
 
@@ -315,7 +315,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-          + "\\[method: POST, uri: http://localhost:\\d+/folio-module2/_/tenant], cause: request timed out")));
+          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
 
@@ -354,7 +354,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-          + "\\[method: POST, uri: http://localhost:\\d+/folio-module2/_/tenant], cause: request timed out")));
+          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
     assertThat(keycloakTestClient.getAuthorizationScopes(TENANT_NAME)).containsExactlyElementsOf(ALL_HTTP_METHODS);
@@ -390,7 +390,7 @@ class FolioEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[11].key", is("folio-module2-2.0.0-moduleInstaller")))
       .andExpect(jsonPath("$.errors[0].parameters[11].value", matchesPattern(
         "FAILED: \\[IntegrationException] \\[IOException] Failed to perform request "
-          + "\\[method: POST, uri: http://localhost:\\d+/folio-module2/_/tenant], "
+          + "\\[method: POST, uri: http://\\w+:\\d+/folio-module2/_/tenant], "
           + "cause: HTTP/1.1 header parser received no bytes")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());

--- a/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
@@ -35,6 +35,8 @@ import static org.folio.entitlement.support.TestValues.extendedEntitlement;
 import static org.folio.entitlement.support.TestValues.extendedEntitlements;
 import static org.folio.entitlement.support.TestValues.queryByTenantAndAppId;
 import static org.folio.test.TestConstants.OKAPI_AUTH_TOKEN;
+import static org.folio.test.extensions.impl.WireMockExtension.WM_DOCKER_PORT;
+import static org.folio.test.extensions.impl.WireMockExtension.WM_NETWORK_ALIAS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -115,7 +117,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
     assertThat(appContext.containsBean("folioKongGatewayService")).isTrue();
     assertThat(appContext.containsBean("folioKongModuleRegistrar")).isFalse();
 
-    var wiremockUrl = "http://host.testcontainers.internal:" + wmAdminClient.getWireMockPort();
+    var wiremockUrl = String.format("http://%s:%s", WM_NETWORK_ALIAS, WM_DOCKER_PORT);
     kongAdminClient.upsertService(OKAPI_MODULE_ID, new Service().name(OKAPI_MODULE_ID).url(wiremockUrl));
     kongAdminClient.upsertService(OKAPI_MODULE_3_ID, new Service().name(OKAPI_MODULE_3_ID).url(wiremockUrl));
     kongAdminClient.upsertService(OKAPI_MODULE_4_ID, new Service().name(OKAPI_MODULE_4_ID).url(wiremockUrl));


### PR DESCRIPTION
## Purpose

Adjusts `EntitlementRoutesIT` to call wiremock container directly by using network alias + docker port

## Approach

- Fix `EntitlementRoutesIT`

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
