### PR TITLE
MGRENTITLE-40 Detached module entities are tried to update with null values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <swagger-annotations.version>2.2.21</swagger-annotations.version>
     <apache-commons-lang3.version>3.14.0</apache-commons-lang3.version>
     <apache-commons-collections4.version>4.4</apache-commons-collections4.version>
-    <cql2pgjson.version>35.2.0</cql2pgjson.version>
+    <cql2pgjson.version>35.2.2</cql2pgjson.version>
     <spring-cloud-bom.version>2023.0.1</spring-cloud-bom.version>
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <semver4j.version>5.2.3</semver4j.version>

--- a/src/main/java/org/folio/entitlement/domain/entity/EntitlementEntity.java
+++ b/src/main/java/org/folio/entitlement/domain/entity/EntitlementEntity.java
@@ -1,24 +1,16 @@
 package org.folio.entitlement.domain.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Set;
 import java.util.UUID;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.folio.entitlement.domain.entity.key.EntitlementKey;
-import org.folio.entitlement.domain.entity.key.EntitlementModuleEntity;
 import org.folio.entitlement.utils.SemverUtils;
 
 @Data
@@ -54,16 +46,6 @@ public class EntitlementEntity implements Serializable {
    */
   @Column(name = "application_version", updatable = false)
   private String applicationVersion;
-
-  /**
-   * A set of entitled modules.
-   */
-  @OneToMany(cascade = {CascadeType.REMOVE}, fetch = FetchType.EAGER)
-  @ToString.Exclude
-  @EqualsAndHashCode.Exclude
-  @JoinColumn(name = "application_id")
-  @JoinColumn(name = "tenant_id")
-  private Set<EntitlementModuleEntity> modules;
 
   /**
    * Sets application name and version from application id.

--- a/src/main/java/org/folio/entitlement/domain/entity/EntitlementEntity.java
+++ b/src/main/java/org/folio/entitlement/domain/entity/EntitlementEntity.java
@@ -1,5 +1,6 @@
 package org.folio.entitlement.domain.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -57,7 +58,7 @@ public class EntitlementEntity implements Serializable {
   /**
    * A set of entitled modules.
    */
-  @OneToMany(fetch = FetchType.LAZY)
+  @OneToMany(cascade = {CascadeType.REMOVE}, fetch = FetchType.EAGER)
   @ToString.Exclude
   @EqualsAndHashCode.Exclude
   @JoinColumn(name = "application_id")

--- a/src/main/java/org/folio/entitlement/mapper/EntitlementMapper.java
+++ b/src/main/java/org/folio/entitlement/mapper/EntitlementMapper.java
@@ -1,7 +1,10 @@
 package org.folio.entitlement.mapper;
 
+import static java.util.stream.Collectors.toList;
+import static org.folio.common.utils.CollectionUtils.toStream;
 import static org.mapstruct.InjectionStrategy.CONSTRUCTOR;
 
+import java.util.List;
 import java.util.UUID;
 import org.folio.entitlement.domain.dto.Entitlement;
 import org.folio.entitlement.domain.entity.EntitlementEntity;
@@ -14,7 +17,6 @@ public interface EntitlementMapper {
 
   @Mapping(target = "applicationName", ignore = true)
   @Mapping(target = "applicationVersion", ignore = true)
-  @Mapping(target = "modules", ignore = true)
   EntitlementEntity map(UUID tenantId, String applicationId);
 
   @Mapping(target = "modules", ignore = true)
@@ -22,12 +24,15 @@ public interface EntitlementMapper {
 
   @Mapping(target = "applicationName", ignore = true)
   @Mapping(target = "applicationVersion", ignore = true)
-  @Mapping(target = "modules", ignore = true)
   EntitlementEntity map(Entitlement entitlement);
 
-  Entitlement mapWithModules(EntitlementEntity entity);
+  default Entitlement mapWithModules(EntitlementEntity entity, List<EntitlementModuleEntity> modules) {
+    var entitlementEntity = map(entity);
+    var modulesList = toStream(modules)
+      .map(EntitlementModuleEntity::getModuleId)
+      .collect(toList());
+    entitlementEntity.setModules(modulesList);
 
-  default String mapModule(EntitlementModuleEntity module) {
-    return module.getModuleId();
+    return entitlementEntity;
   }
 }

--- a/src/main/java/org/folio/entitlement/repository/EntitlementModuleRepository.java
+++ b/src/main/java/org/folio/entitlement/repository/EntitlementModuleRepository.java
@@ -15,4 +15,6 @@ public interface EntitlementModuleRepository extends JpaCqlRepository<Entitlemen
   Page<EntitlementModuleEntity> findAllByModuleId(String moduleId, Pageable pageable);
 
   List<EntitlementModuleEntity> findAllByModuleIdAndTenantId(String moduleId, UUID tenantId);
+
+  List<EntitlementModuleEntity> findAllByApplicationIdAndTenantId(String applicationId, UUID tenantId);
 }

--- a/src/test/java/org/folio/entitlement/it/EntitlementRoutesIT.java
+++ b/src/test/java/org/folio/entitlement/it/EntitlementRoutesIT.java
@@ -262,7 +262,7 @@ class EntitlementRoutesIT extends BaseIntegrationTest {
         .andExpect(status().isCreated());
 
       var routesByTag = kongAdminClient.getRoutesByTag(TENANT_NAME, null);
-      assertThat(routesByTag.getData()).hasSize(11);
+      assertThat(routesByTag.getData()).hasSize(12);
       assertThat(routesByTag.getOffset()).isNull();
 
       assertEntitlementEvents(

--- a/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
@@ -180,14 +180,14 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
     entitleApplications(entitlementRequest(OKAPI_APP_ID), emptyMap(),
       extendedEntitlements(extendedEntitlement(OKAPI_APP_ID)));
     getEntitlementsWithModules(queryByTenantAndAppId(OKAPI_APP_ID), entitlements(entitlement1));
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(2);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
 
     // entitle dependent application
     entitleApplications(entitlementRequest(OKAPI_APP_5_ID), emptyMap(),
       extendedEntitlements(extendedEntitlement(OKAPI_APP_5_ID)));
     var entitlement2 = entitlementWithModules(TENANT_ID, OKAPI_APP_5_ID, List.of(OKAPI_MODULE_5_ID));
     getEntitlementsWithModules(queryByTenantAndAppId(OKAPI_APP_5_ID), entitlements(entitlement2));
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(4);
 
     var savedEntitlementQuery = String.format("applicationId==(%s or %s)", OKAPI_APP_ID, OKAPI_APP_5_ID);
     getEntitlementsWithModules(savedEntitlementQuery, entitlements(entitlement1, entitlement2));
@@ -223,7 +223,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
     var savedEntitlementQuery = String.format("applicationId==(%s or %s)", OKAPI_APP_ID, OKAPI_APP_5_ID);
     getEntitlementsWithModules(savedEntitlementQuery, entitlements(entitlement1, entitlement2));
 
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(4);
 
     assertEntitlementEvents(List.of(
       new EntitlementEvent(ENTITLE.name(), OKAPI_MODULE_ID, TENANT_NAME, TENANT_ID),
@@ -259,7 +259,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
     var entitlement = entitlementWithModules(TENANT_ID, OKAPI_APP_ID, List.of(OKAPI_MODULE_ID));
     getEntitlementsWithModules(queryByTenantAndAppId(OKAPI_APP_ID), entitlements(entitlement));
     assertEntitlementEvents(List.of(new EntitlementEvent(ENTITLE.name(), "okapi-module-1.0.0", "test", TENANT_ID)));
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(2);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
     assertCapabilityEvents(readCapabilityEvent("json/events/okapi-it/okapi-module-capability-event-1.json"));
     assertScheduledJobEvents(readScheduledJobEvent("json/events/okapi-it/scheduled-job-event.json"));
     assertSystemUserEvents(readSystemUserEvent("json/events/okapi-it/system-user-event.json"));
@@ -367,18 +367,18 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
     var expectedExtendedEntitlements = extendedEntitlements(extendedEntitlement(OKAPI_APP_ID));
     entitleApplications(entitlementRequest(OKAPI_APP_ID), queryParams, expectedExtendedEntitlements);
     getEntitlementsByQuery(queryByTenantAndAppId(OKAPI_APP_ID), entitlements(entitlement(OKAPI_APP_ID)));
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(2);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
 
     // entitle application
     var entitlementRequest = entitlementRequest(OKAPI_APP_5_ID);
     entitleApplications(entitlementRequest, queryParams, extendedEntitlements(extendedEntitlement(OKAPI_APP_5_ID)));
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(4);
 
     // revoke entitlement for test application
     var revokeParams = Map.of("purge", "true");
     revokeEntitlements(entitlementRequest, revokeParams, extendedEntitlements(extendedEntitlement(OKAPI_APP_5_ID)));
     getEntitlementsByQuery(queryByTenantAndAppId(OKAPI_APP_5_ID), emptyEntitlements());
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(2);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
 
     // entitle test application again
     entitleApplications(entitlementRequest, queryParams, extendedEntitlements(extendedEntitlement(OKAPI_APP_5_ID)));
@@ -389,7 +389,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
       new EntitlementEvent(REVOKE.name(), OKAPI_MODULE_5_ID, TENANT_NAME, TENANT_ID),
       new EntitlementEvent(ENTITLE.name(), OKAPI_MODULE_5_ID, TENANT_NAME, TENANT_ID)));
     assertCapabilityEvents(readCapabilityEvent("json/events/okapi-it/okapi-module-capability-event-1.json"));
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(4);
   }
 
   @Test
@@ -566,7 +566,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[8].value", startsWith(
         "CANCELLATION_FAILED: [KongIntegrationException] Failed to remove routes, parameters:")));
 
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(1);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(2);
     getEntitlementsByQuery(queryByTenantAndAppId(OKAPI_APP_ID), emptyEntitlements());
   }
 
@@ -596,7 +596,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[9].value", startsWith(
         "FAILED: [BadRequest] [400 Bad Request] during [POST] to")));
 
-    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(2);
+    assertThat(kongAdminClient.getRoutesByTag(TENANT_NAME, null)).hasSize(3);
     getEntitlementsByQuery(queryByTenantAndAppId(OKAPI_APP_ID), emptyEntitlements());
   }
 


### PR DESCRIPTION
## Purpose

This issue has been discovered during installing modules with async=true(not related to the bug) but looks like hibernate dirty check lazy dependency at some point (maybe the session has been detached)

[MGRENTITLE-40](https://folio-org.atlassian.net/browse/MGRENTITLE-40)


## Approach
- delete relations between Entitlement and EntitlementModule. Explicitly load related data on demand
- update tests

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
