### PR TITLE
MGRENTITLE-39 Fix issue with repeat enabling

### DIFF
--- a/src/main/java/org/folio/entitlement/repository/ApplicationFlowRepository.java
+++ b/src/main/java/org/folio/entitlement/repository/ApplicationFlowRepository.java
@@ -35,14 +35,14 @@ public interface ApplicationFlowRepository extends AbstractFlowRepository<Applic
   @Query(nativeQuery = true, value = """
     SELECT DISTINCT af.* FROM {h-schema}application_flow af
     INNER JOIN (
-      SELECT MAX(finished_at) AS finished_at, tenant_id, application_id
+      SELECT MAX(finished_at) AS finished_at, tenant_id, application_name
       FROM {h-schema}application_flow af
       WHERE af.tenant_id = :tenant_id
         AND af.application_name IN :application_names
-      GROUP BY tenant_id, application_id
+      GROUP BY tenant_id, application_name
     ) laf ON af.finished_at = laf.finished_at
           AND af.tenant_id = laf.tenant_id
-          AND af.application_id = laf.application_id""")
+          AND af.application_name = laf.application_name""")
   List<ApplicationFlowEntity> findLastFlowsByApplicationNames(
     @Param("application_names") Collection<String> applicationNames, @Param("tenant_id") UUID tenantId);
 

--- a/src/main/java/org/folio/entitlement/service/stage/FlowInitializer.java
+++ b/src/main/java/org/folio/entitlement/service/stage/FlowInitializer.java
@@ -20,6 +20,7 @@ public class FlowInitializer extends DatabaseLoggingStage<CommonStageContext> {
     var entitlementRequest = context.getEntitlementRequest();
     var flow = new Flow()
       .id(context.getCurrentFlowId())
+      .tenantId(entitlementRequest.getTenantId())
       .status(ExecutionStatus.IN_PROGRESS)
       .type(entitlementRequest.getType())
       .startedAt(Date.from(Instant.now()));


### PR DESCRIPTION
## Purpose

Fixes an issue when the sequence of enabling, upgrading, revoking, and enabling the initial application failed because of an invalid SQL query.
This query returns 2 application flows - first enable and the latest for the revoke operation, which has the same application name, but different version.

## Approach
- Fix SQL query for retrieving last application flows by name
- Add tenant_id to the flow entity (missing in first PR)

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
