### PR TITLE
MGRENTITLE-62 Fix ApplicationFlowValidator to forbid installing lower versions

### DIFF
--- a/src/test/resources/sql/okapi-app-upgraded.sql
+++ b/src/test/resources/sql/okapi-app-upgraded.sql
@@ -1,0 +1,21 @@
+INSERT INTO entitlement(application_id, application_name, application_version, tenant_id)
+VALUES ('okapi-app-1.1.0', 'okapi-app', '1.1.0', '6ad28dae-7c02-4f89-9320-153c55bf1914');
+
+INSERT INTO entitlement_module(module_id, tenant_id, application_id)
+VALUES ('okapi-module-1.1.0', '6ad28dae-7c02-4f89-9320-153c55bf1914', 'okapi-app-1.1.0');
+
+INSERT INTO flow(flow_id, tenant_id, type, status, started_at, finished_at)
+VALUES ('56a99f07-b5b9-4fd5-bd04-e26b4ed25182', '6ad28dae-7c02-4f89-9320-153c55bf1914', 'ENTITLE',
+        'FINISHED', '2022-01-01 09:00:00', '2022-01-01 09:20:40'),
+       ('f79cedce-4ec9-4b23-aaea-e759f34d4b8b', '6ad28dae-7c02-4f89-9320-153c55bf1914', 'UPGRADE',
+        'FINISHED', '2022-01-01 10:00:00', '2022-01-01 10:20:40');
+
+INSERT INTO application_flow(application_flow_id, application_id, application_name, application_version,
+                             tenant_id, flow_id, type, status, started_at, finished_at)
+VALUES ('22556baa-0644-489f-a7b3-8f854bbcfc8c', 'okapi-app-1.0.0', 'okapi-app', '1.0.0',
+        '6ad28dae-7c02-4f89-9320-153c55bf1914', '56a99f07-b5b9-4fd5-bd04-e26b4ed25182', 'ENTITLE', 'FINISHED',
+        '2022-01-01 09:00:00', '2022-01-01 09:20:35'),
+       ('66540821-4291-42b4-8752-ea674d03fbbf', 'okapi-app-1.1.0', 'okapi-app', '1.1.0',
+        '6ad28dae-7c02-4f89-9320-153c55bf1914', 'f79cedce-4ec9-4b23-aaea-e759f34d4b8b', 'UPGRADE', 'FINISHED',
+        '2022-01-01 10:00:00', '2022-01-01 10:20:35');
+


### PR DESCRIPTION
## Purpose

 Fix ApplicationFlowValidator to forbid installing lower versions of applications after upgrade

## Approach
- Update ApplicationFlowValidator
- Update unit tests

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
