### PR TITLE
MGRENTITLE-63 Use metadata field instead of removed extensions

### DIFF
--- a/src/main/java/org/folio/entitlement/utils/SystemUserEventProvider.java
+++ b/src/main/java/org/folio/entitlement/utils/SystemUserEventProvider.java
@@ -38,7 +38,7 @@ public class SystemUserEventProvider {
       return Optional.empty();
     }
 
-    var extensions = moduleDescriptor.getExtensions();
+    var extensions = moduleDescriptor.getMetadata();
     if (extensions != null && MapUtils.isNotEmpty(extensions.properties())) {
       var extensionsUserDescriptor = extensions.properties().get(EXTENSIONS_USER_FIELD);
       return Optional.ofNullable(objectMapper.convertValue(extensionsUserDescriptor, UserDescriptor.class));

--- a/src/test/java/org/folio/entitlement/utils/SystemUserEventProviderTest.java
+++ b/src/test/java/org/folio/entitlement/utils/SystemUserEventProviderTest.java
@@ -50,12 +50,12 @@ class SystemUserEventProviderTest {
 
   @Test
   @Deprecated
-  void getSystemUserEvent_positive_extensionsSection() throws JsonProcessingException {
+  void getSystemUserEvent_positive_metadataSection() throws JsonProcessingException {
     var moduleDescriptorJson = """
       {
         "id": "test-module-0.0.1",
         "name": "Test Module",
-        "extensions": {
+        "metadata": {
           "user": { "type": "system", "permissions": [ "test.permission" ] }
         }
       }""";
@@ -69,12 +69,12 @@ class SystemUserEventProviderTest {
 
   @Test
   @Deprecated
-  void getSystemUserEvent_positive_unknownExtensionKey() throws JsonProcessingException {
+  void getSystemUserEvent_positive_unknownMetadataKey() throws JsonProcessingException {
     var moduleDescriptorJson = """
       {
         "id": "test-module-0.0.1",
         "name": "Test Module",
-        "extensions": { "unknown": { "key": "value" } }
+        "metadata": { "unknown": { "key": "value" } }
       }""";
 
     var moduleDescriptor = OBJECT_MAPPER.readValue(moduleDescriptorJson, ModuleDescriptor.class);

--- a/src/test/resources/wiremock/mgr-applications/folio-app6/v2-get-by-ids-query-full.json
+++ b/src/test/resources/wiremock/mgr-applications/folio-app6/v2-get-by-ids-query-full.json
@@ -218,7 +218,7 @@
                   "description": "Get a folio-module2 entity by id"
                 }
               ],
-              "extensions": {
+              "metadata": {
                 "user": {
                   "type": "module",
                   "permissions": [
@@ -284,7 +284,7 @@
                   "description": "Get a folio-module4 entity by id"
                 }
               ],
-              "extensions": {
+              "metadata": {
                 "user": {
                   "type": "module",
                   "permissions": [ "folio-module1.entity.item.post" ]


### PR DESCRIPTION
## Purpose

Use metadata field instead of `extensions` as system user source

## Approach

- Change `extensions` to `metadata` for system user search
- Adjust unit and integration tests

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
