### PR TITLE
MODCONSKC-7: move system user publisher stage before module installer…

### DIFF
--- a/src/main/java/org/folio/entitlement/integration/folio/flow/FolioModuleEntitleFlowFactory.java
+++ b/src/main/java/org/folio/entitlement/integration/folio/flow/FolioModuleEntitleFlowFactory.java
@@ -38,8 +38,8 @@ public class FolioModuleEntitleFlowFactory implements ModuleFlowFactory {
       .stage(systemUserEventPublisher)
       .stage(folioModuleInstaller)
       .stage(folioModuleEventPublisher)
-      .stage(combineStages("EventPublishingParallelStage", asList(
-        scheduledJobEventPublisher, capabilitiesEventPublisher)))
+      .stage(combineStages("EventPublishingParallelStage",
+        asList(scheduledJobEventPublisher, capabilitiesEventPublisher)))
       .executionStrategy(strategy)
       .flowParameters(additionalFlowParameters)
       .build();

--- a/src/main/java/org/folio/entitlement/integration/folio/flow/FolioModuleEntitleFlowFactory.java
+++ b/src/main/java/org/folio/entitlement/integration/folio/flow/FolioModuleEntitleFlowFactory.java
@@ -35,10 +35,11 @@ public class FolioModuleEntitleFlowFactory implements ModuleFlowFactory {
     return Flow.builder()
       .id(flowId)
       .stage(combineStages("ResourceCreatorParallelStage", asList(kongModuleRouteCreator, kcModuleResourceCreator)))
+      .stage(systemUserEventPublisher)
       .stage(folioModuleInstaller)
       .stage(folioModuleEventPublisher)
       .stage(combineStages("EventPublishingParallelStage", asList(
-        systemUserEventPublisher, scheduledJobEventPublisher, capabilitiesEventPublisher)))
+        scheduledJobEventPublisher, capabilitiesEventPublisher)))
       .executionStrategy(strategy)
       .flowParameters(additionalFlowParameters)
       .build();

--- a/src/main/java/org/folio/entitlement/integration/folio/flow/FolioModuleUpgradeFlowFactory.java
+++ b/src/main/java/org/folio/entitlement/integration/folio/flow/FolioModuleUpgradeFlowFactory.java
@@ -36,10 +36,11 @@ public class FolioModuleUpgradeFlowFactory implements ModuleFlowFactory {
       .id(flowId)
       .executionStrategy(strategy)
       .stage(combineStages("ResourceUpdaterParallelStage", asList(kongModuleRouteUpdater, kcModuleResourceUpdater)))
+      .stage(systemUserEventPublisher)
       .stage(folioModuleUpdater)
       .stage(folioModuleEventPublisher)
       .stage(combineStages("EventPublishingParallelStage",
-        asList(systemUserEventPublisher, scheduledJobEventPublisher, capabilitiesEventPublisher)))
+        asList(scheduledJobEventPublisher, capabilitiesEventPublisher)))
       .flowParameters(additionalFlowParameters)
       .build();
   }

--- a/src/main/java/org/folio/entitlement/integration/okapi/flow/OkapiModulesEntitleFlowFactory.java
+++ b/src/main/java/org/folio/entitlement/integration/okapi/flow/OkapiModulesEntitleFlowFactory.java
@@ -36,9 +36,10 @@ public class OkapiModulesEntitleFlowFactory implements OkapiModulesFlowFactory {
     return Flow.builder()
       .id(context.flowId() + "/OkapiModulesEntitleFlow")
       .stage(combineStages("ParallelResourcesCleaner", asList(kongRouteCreator, keycloakAuthResourceCreator)))
+      .stage(systemUserEventPublisher)
       .stage(okapiModulesInstaller)
-      .stage(combineStages("EventPublishingParallelStage", asList(
-        systemUserEventPublisher, scheduledJobEventPublisher, capabilitiesEventPublisher)))
+      .stage(combineStages("EventPublishingParallelStage",
+        asList(scheduledJobEventPublisher, capabilitiesEventPublisher)))
       .stage(okapiModulesEventPublisher)
       .executionStrategy(request.getExecutionStrategy())
       .flowParameters(additionalFlowParameters)

--- a/src/test/java/org/folio/entitlement/integration/folio/flow/FolioModuleEntitleFlowFactoryTest.java
+++ b/src/test/java/org/folio/entitlement/integration/folio/flow/FolioModuleEntitleFlowFactoryTest.java
@@ -74,9 +74,9 @@ class FolioModuleEntitleFlowFactoryTest {
     var stageContext = moduleStageContext(FLOW_STAGE_ID, flowParameters, emptyMap());
     verifyStageExecution(inOrder, kongModuleRouteCreator, stageContext);
     verifyStageExecution(inOrder, kcModuleResourceCreator, stageContext);
+    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, folioModuleInstaller, stageContext);
     verifyStageExecution(inOrder, folioModuleEventPublisher, stageContext);
-    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, scheduledJobEventPublisher, stageContext);
     verifyStageExecution(inOrder, capabilitiesEventPublisher, stageContext);
   }
@@ -95,9 +95,9 @@ class FolioModuleEntitleFlowFactoryTest {
       scheduledJobEventPublisher, capabilitiesEventPublisher, folioModuleInstaller);
 
     var stageContext = moduleStageContext(FLOW_STAGE_ID, flowParameters, emptyMap());
+    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, folioModuleInstaller, stageContext);
     verifyStageExecution(inOrder, folioModuleEventPublisher, stageContext);
-    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, scheduledJobEventPublisher, stageContext);
     verifyStageExecution(inOrder, capabilitiesEventPublisher, stageContext);
   }

--- a/src/test/java/org/folio/entitlement/integration/folio/flow/FolioModuleUpgradeFlowFactoryTest.java
+++ b/src/test/java/org/folio/entitlement/integration/folio/flow/FolioModuleUpgradeFlowFactoryTest.java
@@ -74,9 +74,9 @@ class FolioModuleUpgradeFlowFactoryTest {
     var stageContext = moduleStageContext(FLOW_STAGE_ID, flowParameters, emptyMap());
     verifyStageExecution(inOrder, kongModuleRouteUpdater, stageContext);
     verifyStageExecution(inOrder, kcModuleResourceUpdater, stageContext);
+    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, folioModuleUpdater, stageContext);
     verifyStageExecution(inOrder, folioModuleEventPublisher, stageContext);
-    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, scheduledJobEventPublisher, stageContext);
     verifyStageExecution(inOrder, capabilitiesEventPublisher, stageContext);
   }
@@ -93,9 +93,9 @@ class FolioModuleUpgradeFlowFactoryTest {
     var inOrder = inOrder(capabilitiesEventPublisher, scheduledJobEventPublisher,
       systemUserEventPublisher, folioModuleUpdater, folioModuleEventPublisher);
     var stageContext = moduleStageContext(FLOW_STAGE_ID, flowParameters, emptyMap());
+    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, folioModuleUpdater, stageContext);
     verifyStageExecution(inOrder, folioModuleEventPublisher, stageContext);
-    verifyStageExecution(inOrder, systemUserEventPublisher, stageContext);
     verifyStageExecution(inOrder, scheduledJobEventPublisher, stageContext);
     verifyStageExecution(inOrder, capabilitiesEventPublisher, stageContext);
 

--- a/src/test/java/org/folio/entitlement/integration/okapi/flow/OkapiModulesEntitleFlowFactoryTest.java
+++ b/src/test/java/org/folio/entitlement/integration/okapi/flow/OkapiModulesEntitleFlowFactoryTest.java
@@ -76,10 +76,10 @@ class OkapiModulesEntitleFlowFactoryTest {
     var okapiStageContext = okapiStageContext(flowId, emptyMap(), emptyMap());
     verifyStageExecution(inOrder, kongRouteCreator, okapiStageContext);
     verifyStageExecution(inOrder, keycloakAuthResourceCreator, okapiStageContext);
+    verifyStageExecution(inOrder, systemUserEventPublisher, okapiStageContext);
     verifyStageExecution(inOrder, okapiModulesInstaller, okapiStageContext);
 
     var expectedStageContext = appStageContext(flowId, emptyMap(), emptyMap());
-    verifyStageExecution(inOrder, systemUserEventPublisher, okapiStageContext);
     verifyStageExecution(inOrder, scheduledJobEventPublisher, okapiStageContext);
     verifyStageExecution(inOrder, capabilitiesEventPublisher, okapiStageContext);
     verifyStageExecution(inOrder, okapiModulesEventPublisher, okapiStageContext);
@@ -102,8 +102,8 @@ class OkapiModulesEntitleFlowFactoryTest {
     var flowId = FLOW_STAGE_ID + "/OkapiModulesEntitleFlow";
     var expectedStageContext = appStageContext(flowId, emptyMap(), emptyMap());
     var okapiStageContext = okapiStageContext(flowId, emptyMap(), emptyMap());
-    verifyStageExecution(inOrder, okapiModulesInstaller, okapiStageContext);
     verifyStageExecution(inOrder, systemUserEventPublisher, okapiStageContext);
+    verifyStageExecution(inOrder, okapiModulesInstaller, okapiStageContext);
     verifyStageExecution(inOrder, scheduledJobEventPublisher, okapiStageContext);
     verifyStageExecution(inOrder, capabilitiesEventPublisher, okapiStageContext);
     verifyStageExecution(inOrder, okapiModulesEventPublisher, okapiStageContext);


### PR DESCRIPTION

## Purpose
https://folio-org.atlassian.net/browse/MODCONSKC-7
Some modules need to have system user already created for initializing a module for a tenant. 
## Approach

- move system user publisher before module installer
- fix tests


## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
