### PR TITLE
APPPOCTOOL-28 Use folio-auth-openid library for JWT validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ The feature is controlled by two env variables `SECURITY_ENABLED` and `KEYCLOAK_
 | KC_CLIENT_TLS_TRUSTSTORE_PATH     | -                          |    false    | Truststore file path for keycloak clients.                                                                                                                       |
 | KC_CLIENT_TLS_TRUSTSTORE_PASSWORD | -                          |    false    | Truststore password for keycloak clients.                                                                                                                        |
 | KC_CLIENT_TLS_TRUSTSTORE_TYPE     | -                          |    false    | Truststore file type for keycloak clients.                                                                                                                       |
+| KC_AUTH_TOKEN_VALIDATE_URI        | false                      |    false    | Defines if validation for JWT must be run to compare configuration URL and token issuer for keycloak.                                                            |
+| KC_JWKS_REFRESH_INTERVAL          | 60                         |    false    | Jwks refresh interval for realm JWT parser (in minutes).                                                                                                         |
+| KC_FORCED_JWKS_REFRESH_INTERVAL   | 60                         |    false    | Forced jwks refresh interval for realm JWT parser (used in signing key rotation, in minutes).                                                                    |
 
 ## Kong Gateway Integration
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,6 +98,10 @@ application:
       enabled: ${KC_IMPORT_ENABLED:false}
     client:
       client_id: ${KC_CLIENT_ID:mgr-tenant-entitlements}
+    jwt-cache-configuration:
+      validate-uri: ${KC_AUTH_TOKEN_VALIDATE_URI:false}
+      jwks-refresh-interval: ${KC_JWKS_REFRESH_INTERVAL:60}
+      forced-jwks-refresh-interval: ${KC_FORCED_JWKS_REFRESH_INTERVAL:60}
   environment: ${ENV:folio}
   kafka:
     send-duration-timeout: ${KAFKA_SEND_DURATION_TIMEOUT:10s}

--- a/src/test/java/org/folio/entitlement/it/EntitlementApplicationServiceIT.java
+++ b/src/test/java/org/folio/entitlement/it/EntitlementApplicationServiceIT.java
@@ -13,11 +13,13 @@ import org.folio.common.utils.OkapiHeaders;
 import org.folio.entitlement.support.KeycloakTestClientConfiguration;
 import org.folio.entitlement.support.KeycloakTestClientConfiguration.KeycloakTestClient;
 import org.folio.entitlement.support.base.BaseIntegrationTest;
+import org.folio.jwt.openid.OpenidJwtParserProvider;
 import org.folio.test.extensions.EnableKeycloakSecurity;
 import org.folio.test.extensions.EnableKeycloakTlsMode;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -39,6 +41,15 @@ class EntitlementApplicationServiceIT extends BaseIntegrationTest {
   private static final String TEST_TENANT2 = "test2";
 
   @Autowired private KeycloakTestClient keycloakTestClient;
+
+  /**
+   * Invalidates cache before each test because keycloak realm is always recreates, so it prevents old keys to work for
+   * newly issued tokens.
+   */
+  @BeforeEach
+  void setUp(@Autowired OpenidJwtParserProvider openidJwtParserProvider) {
+    openidJwtParserProvider.invalidateCache();
+  }
 
   @Test
   @WireMockStub(scripts = {

--- a/src/test/java/org/folio/entitlement/it/FolioEntitlementSecuredPathPrefixIT.java
+++ b/src/test/java/org/folio/entitlement/it/FolioEntitlementSecuredPathPrefixIT.java
@@ -1,9 +1,11 @@
 package org.folio.entitlement.it;
 
 import org.folio.entitlement.support.KeycloakTestClientConfiguration.KeycloakTestClient;
+import org.folio.jwt.openid.OpenidJwtParserProvider;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -25,6 +27,15 @@ class FolioEntitlementSecuredPathPrefixIT extends AbstractFolioEntitlementIT {
     var accessTokenString = accessTokenResponse.getToken();
     System.setProperty(ROUTER_PATH_PREFIX_SYSTEM_PROPERTY_KEY, "mte");
     System.setProperty(SYSTEM_ACCESS_TOKEN_SYSTEM_PROPERTY_KEY, accessTokenString);
+  }
+
+  /**
+   * Invalidates cache before each test because keycloak realm is always recreates, so it prevents old keys to work for
+   * newly issued tokens.
+   */
+  @BeforeEach
+  void setUp(@Autowired OpenidJwtParserProvider openidJwtParserProvider) {
+    openidJwtParserProvider.invalidateCache();
   }
 
   @AfterAll

--- a/src/test/java/org/folio/entitlement/it/FolioEntitlementWithSecurityIT.java
+++ b/src/test/java/org/folio/entitlement/it/FolioEntitlementWithSecurityIT.java
@@ -1,9 +1,11 @@
 package org.folio.entitlement.it;
 
 import org.folio.entitlement.support.KeycloakTestClientConfiguration.KeycloakTestClient;
+import org.folio.jwt.openid.OpenidJwtParserProvider;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -23,6 +25,15 @@ class FolioEntitlementWithSecurityIT extends FolioEntitlementIT {
     var accessTokenResponse = keycloak.tokenManager().grantToken();
     var accessTokenString = accessTokenResponse.getToken();
     System.setProperty(SYSTEM_ACCESS_TOKEN_SYSTEM_PROPERTY_KEY, accessTokenString);
+  }
+
+  /**
+   * Invalidates cache before each test because keycloak realm is always recreates, so it prevents old keys to work for
+   * newly issued tokens.
+   */
+  @BeforeEach
+  void setUp(@Autowired OpenidJwtParserProvider openidJwtParserProvider) {
+    openidJwtParserProvider.invalidateCache();
   }
 
   @AfterAll

--- a/src/test/java/org/folio/entitlement/support/TestUtils.java
+++ b/src/test/java/org/folio/entitlement/support/TestUtils.java
@@ -1,5 +1,7 @@
 package org.folio.entitlement.support;
 
+import static javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier;
+import static javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory;
 import static javax.net.ssl.SSLContext.getInstance;
 import static org.folio.common.utils.ExceptionHandlerUtils.buildValidationError;
 import static org.mockito.Mockito.when;
@@ -26,8 +28,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import lombok.AccessLevel;
@@ -171,6 +175,22 @@ public class TestUtils {
       .build();
 
     return (BadRequest) FeignException.errorStatus("someMethod", response);
+  }
+
+  public static void disableSslVerification() {
+    try {
+      var sc = dummySslContext();
+      setDefaultSSLSocketFactory(sc.getSocketFactory());
+      var allHostsValid = new HostnameVerifier() {
+        public boolean verify(String hostname, SSLSession session) {
+          return true;
+        }
+      };
+
+      setDefaultHostnameVerifier(allHostsValid);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to disable SSL verification", e);
+    }
   }
 
   public static HttpClient httpClientWithDummySslContext() {

--- a/src/test/java/org/folio/entitlement/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/entitlement/support/base/BaseIntegrationTest.java
@@ -22,6 +22,7 @@ import org.folio.entitlement.domain.dto.EntitlementRequestBody;
 import org.folio.entitlement.domain.dto.Entitlements;
 import org.folio.entitlement.domain.dto.ExtendedEntitlements;
 import org.folio.entitlement.exception.RequestValidationException;
+import org.folio.entitlement.support.TestUtils;
 import org.folio.entitlement.support.extensions.EnableKongGateway;
 import org.folio.entitlement.support.extensions.EnablePostgres;
 import org.folio.test.FakeKafkaConsumer;
@@ -76,6 +77,10 @@ public abstract class BaseIntegrationTest extends BaseBackendIntegrationTest {
 
   protected static FakeKafkaConsumer fakeKafkaConsumer;
   protected static WireMockAdminClient wmAdminClient;
+
+  static {
+    TestUtils.disableSslVerification();
+  }
 
   @BeforeAll
   static void setUp(@Autowired FakeKafkaConsumer consumer) {


### PR DESCRIPTION
## Purpose

Injects and uses a common library for an authentication process.

## Approach

- Use `folio-auth-openid` as a dependency for JWT verification
- Adjust unit and integration tests

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
