### PR TITLE
MGRENTITLE-75: remove routes while purge=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,9 @@ _The behaviour is the same as calling `POST /entitlements` with `ignoreErrors=tr
 
 _The `purge` flag defines whether the tenant application data will be deleted. If this flag is set to true -
 `mgr-tenant-entitlement` will delete all resources, including routes, keycloak authorization resources, and module
-database data (using tenant API) from the system. If this flag is set to `false` - only sidecars for this tenant will
-be disabled and module requests will return an error, saying that the tenant is not enabled._
+database data (using tenant API) from the system. If this flag is set to `false` - sidecars for this tenant will
+be disabled and module requests will return an error, saying that the tenant is not enabled. Also routes in Kong will
+be deleted._
 
 ### Is rollbacks are supported for the application uninstalling/upgrades?
 

--- a/src/main/java/org/folio/entitlement/integration/kong/KongModuleRouteCleaner.java
+++ b/src/main/java/org/folio/entitlement/integration/kong/KongModuleRouteCleaner.java
@@ -13,11 +13,6 @@ public class KongModuleRouteCleaner extends ModuleDatabaseLoggingStage {
 
   @Override
   public void execute(ModuleStageContext context) {
-    var request = context.getEntitlementRequest();
-    if (!request.isPurge()) {
-      return;
-    }
-
     var moduleDescriptor = context.getModuleDescriptor();
     kongGatewayService.removeRoutes(context.getTenantName(), List.of(moduleDescriptor));
   }

--- a/src/main/java/org/folio/entitlement/integration/kong/KongRouteCleaner.java
+++ b/src/main/java/org/folio/entitlement/integration/kong/KongRouteCleaner.java
@@ -12,11 +12,6 @@ public class KongRouteCleaner extends DatabaseLoggingStage<OkapiStageContext> {
 
   @Override
   public void execute(OkapiStageContext context) {
-    var request = context.getEntitlementRequest();
-    if (!request.isPurge()) {
-      return;
-    }
-
     kongGatewayService.removeRoutes(context.getTenantName(), context.getModuleDescriptors());
   }
 }

--- a/src/main/resources/swagger.api/mgr-tenant-entitlements.yaml
+++ b/src/main/resources/swagger.api/mgr-tenant-entitlements.yaml
@@ -499,8 +499,8 @@ components:
       description: |
         Defines if create by entitlement process resources must be purged, including:
           - Keycloak authorization resources (if integration is enabled)
-          - Kong routes (if integration is enabled)
           - Folio modules data (_tenant API request will be performed with parameter: purge=true)
+        Kong routes will be removed in any case.
       required: false
       schema:
         type: boolean

--- a/src/test/java/org/folio/entitlement/integration/kong/KongModuleRouteCleanerTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kong/KongModuleRouteCleanerTest.java
@@ -7,7 +7,6 @@ import static org.folio.entitlement.support.TestConstants.FLOW_STAGE_ID;
 import static org.folio.entitlement.support.TestConstants.TENANT_NAME;
 import static org.folio.entitlement.support.TestValues.moduleStageContext;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,7 @@ class KongModuleRouteCleanerTest {
 
     kongModuleRouteCleaner.execute(stageContext);
 
-    verifyNoInteractions(kongGatewayService);
+    verify(kongGatewayService).removeRoutes(TENANT_NAME, List.of(moduleDescriptor));
   }
 
   @Test

--- a/src/test/java/org/folio/entitlement/integration/kong/KongRouteCleanerTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kong/KongRouteCleanerTest.java
@@ -9,7 +9,6 @@ import static org.folio.entitlement.support.TestConstants.TENANT_NAME;
 import static org.folio.entitlement.support.TestValues.applicationDescriptor;
 import static org.folio.entitlement.support.TestValues.okapiStageContext;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 import java.util.Map;
@@ -60,7 +59,7 @@ class KongRouteCleanerTest {
 
     kongRouteCleaner.execute(stageContext);
 
-    verifyNoInteractions(kongGatewayService);
+    verify(kongGatewayService).removeRoutes(TENANT_NAME, moduleDescriptors);
   }
 
   private static OkapiStageContext stageContext(EntitlementRequest request, ApplicationDescriptor desc) {


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MGRENTITLE-75
Application was disabled for all tenants. Parsms: /entitlements?async=true&purge=false
Found that resources in Kong are still present.

## Approach

- remove routes anytime disabling application is called
- update tests 
- update docs

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
