### PR TITLE
MGRENTITLE-81

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ docker run \
 | FLOW_ENGINE_THREADS_NUM                | 4                                   |  false   | Defines the number of threads for Fork-Join Pool used by flow engine.                                                                                                                                      |
 | REGISTER_MODULE_IN_KONG                | true                                |  false   | Defines if module must be registered in Kong (it will create for itself service and list of routes from module descriptor)                                                                                 |
 | ROUTER_PATH_PREFIX                     |                                     |  false   | Defines routes prefix to be added to the generated endpoints by OpenAPI generator (`/foo/entites` -> `{{prefix}}/foo/entities`). Required if load balancing group has format like `{{host}}/{{moduleId}}`  |
+| ROUTEMANAGEMENT_ENABLE                 | true                                |  false   | Enable Kong routes management for modules on entitlement/unentitlement                                                                                                                                     |
 
 ### Validators environment variables
 

--- a/src/main/java/org/folio/entitlement/integration/kong/KongConfiguration.java
+++ b/src/main/java/org/folio/entitlement/integration/kong/KongConfiguration.java
@@ -14,12 +14,14 @@ import org.folio.entitlement.service.stage.ThreadLocalModuleStageContext;
 import org.folio.tools.kong.client.KongAdminClient;
 import org.folio.tools.kong.configuration.KongConfigurationProperties;
 import org.folio.tools.kong.service.KongGatewayService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnProperty(prefix = "application.kong", name = "enabled")
+@ConditionalOnExpression("${routemanagement.enable:true}")
 public class KongConfiguration {
 
   /**

--- a/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementDisabledTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementDisabledTest.java
@@ -1,0 +1,70 @@
+package org.folio.entitlement.integration.kong;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.folio.entitlement.integration.folio.flow.FolioModuleEntitleFlowFactory;
+import org.folio.entitlement.integration.folio.stage.FolioModuleEventPublisher;
+import org.folio.entitlement.integration.folio.stage.FolioModuleInstaller;
+import org.folio.entitlement.integration.kafka.CapabilitiesModuleEventPublisher;
+import org.folio.entitlement.integration.kafka.ScheduledJobModuleEventPublisher;
+import org.folio.entitlement.integration.kafka.SystemUserModuleEventPublisher;
+import org.folio.entitlement.integration.keycloak.KeycloakModuleResourceCreator;
+import org.folio.entitlement.repository.FlowStageRepository;
+import org.folio.entitlement.service.stage.ThreadLocalModuleStageContext;
+import org.folio.flow.model.FlowExecutionStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(properties = {"routemanagement.enable=false"})
+@ContextConfiguration(classes = {KongConfiguration.class, KongRouteManagementDisabledTest.TestConfig.class})
+public class KongRouteManagementDisabledTest {
+
+  @Autowired private FolioModuleEntitleFlowFactory flowFactory;
+
+  @Test
+  public void testFlowFactory() {
+    var flow = flowFactory.createModuleFlow("123", FlowExecutionStrategy.IGNORE_ON_ERROR, Map.of());
+    // Check that we have a keycloak module resource creator stage, but not a ResourceCreatorParallelStage
+    // stage that does both Kong routes and Keycloak resources creation
+    assertThat(flow.getStages().stream().filter(stage -> "ResourceCreatorParallelStage".equals(stage.getStageId()))
+      .findAny()).isEmpty();
+    assertThat(flow.getStages().stream().filter(stage -> "KeycloakModuleResourceCreator".equals(stage.getStageId()))
+      .findAny()).isPresent();
+  }
+
+  public static class TestConfig {
+
+    @Bean
+    public FolioModuleEntitleFlowFactory folioModuleEntitleFlowFactory() {
+      return new FolioModuleEntitleFlowFactory(mock(FolioModuleInstaller.class), mock(FolioModuleEventPublisher.class),
+        mock(SystemUserModuleEventPublisher.class), mock(ScheduledJobModuleEventPublisher.class),
+        mock(CapabilitiesModuleEventPublisher.class));
+    }
+
+    @Bean
+    public KeycloakModuleResourceCreator keycloakModuleResourceCreator() {
+      var mock = mock(KeycloakModuleResourceCreator.class);
+      when(mock.getId()).thenReturn("KeycloakModuleResourceCreator");
+      return mock;
+    }
+
+    @Bean
+    public FlowStageRepository flowStageRepository() {
+      return mock(FlowStageRepository.class);
+    }
+
+    @Bean
+    public ThreadLocalModuleStageContext threadLocalModuleStageContext() {
+      return mock(ThreadLocalModuleStageContext.class);
+    }
+  }
+}

--- a/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementDisabledTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementDisabledTest.java
@@ -26,12 +26,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {"routemanagement.enable=false"})
 @ContextConfiguration(classes = {KongConfiguration.class, KongRouteManagementDisabledTest.TestConfig.class})
-public class KongRouteManagementDisabledTest {
+class KongRouteManagementDisabledTest {
 
   @Autowired private FolioModuleEntitleFlowFactory flowFactory;
 
   @Test
-  public void testFlowFactory() {
+  void testFlowFactory() {
     var flow = flowFactory.createModuleFlow("123", FlowExecutionStrategy.IGNORE_ON_ERROR, Map.of());
     // Check that we have a keycloak module resource creator stage, but not a ResourceCreatorParallelStage
     // stage that does both Kong routes and Keycloak resources creation

--- a/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementEnabledTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementEnabledTest.java
@@ -1,0 +1,124 @@
+package org.folio.entitlement.integration.kong;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import feign.Contract;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import java.util.Map;
+import okhttp3.OkHttpClient;
+import org.folio.entitlement.configuration.RetryConfigurationProperties;
+import org.folio.entitlement.integration.folio.flow.FolioModuleEntitleFlowFactory;
+import org.folio.entitlement.integration.folio.stage.FolioModuleEventPublisher;
+import org.folio.entitlement.integration.folio.stage.FolioModuleInstaller;
+import org.folio.entitlement.integration.kafka.CapabilitiesModuleEventPublisher;
+import org.folio.entitlement.integration.kafka.ScheduledJobModuleEventPublisher;
+import org.folio.entitlement.integration.kafka.SystemUserModuleEventPublisher;
+import org.folio.entitlement.integration.keycloak.KeycloakModuleResourceCreator;
+import org.folio.entitlement.repository.FlowStageRepository;
+import org.folio.entitlement.service.stage.ThreadLocalModuleStageContext;
+import org.folio.flow.model.FlowExecutionStrategy;
+import org.folio.tools.kong.client.KongAdminClient;
+import org.folio.tools.kong.configuration.KongConfigurationProperties;
+import org.folio.tools.kong.service.KongGatewayService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(properties = {"routemanagement.enable=true"})
+@ContextConfiguration(classes = {KongRouteManagementEnabledTest.KongConfigExt.class,
+  KongRouteManagementEnabledTest.TestConfig.class})
+public class KongRouteManagementEnabledTest {
+
+  @Autowired private FolioModuleEntitleFlowFactory flowFactory;
+
+  @Test
+  public void testFlowFactory() {
+    var flow = flowFactory.createModuleFlow("123", FlowExecutionStrategy.IGNORE_ON_ERROR, Map.of());
+    // Check that we have a ResourceCreatorParallelStage resource creator stage that does both Kong routes
+    // and Keycloak resources creation, but not a separate KeycloakModuleResourceCreator stage
+    assertThat(flow.getStages().stream().filter(stage -> "ResourceCreatorParallelStage".equals(stage.getStageId()))
+      .findAny()).isPresent();
+    assertThat(flow.getStages().stream().filter(stage -> "KeycloakModuleResourceCreator".equals(stage.getStageId()))
+      .findAny()).isEmpty();
+  }
+
+  public static class KongConfigExt extends KongConfiguration {
+
+    @Bean(name = "folioKongAdminClient")
+    public KongAdminClient folioKongIntegrationClient(okhttp3.OkHttpClient okHttpClient,
+      KongConfigurationProperties properties, Contract contract, Encoder encoder, Decoder decoder,
+      RetryConfigurationProperties retryConfig, ThreadLocalModuleStageContext threadLocalModuleStageContext) {
+      return mock(KongAdminClient.class);
+    }
+  }
+
+  public static class TestConfig {
+
+    @Bean
+    public FolioModuleEntitleFlowFactory folioModuleEntitleFlowFactory() {
+      return new FolioModuleEntitleFlowFactory(mock(FolioModuleInstaller.class), mock(FolioModuleEventPublisher.class),
+        mock(SystemUserModuleEventPublisher.class), mock(ScheduledJobModuleEventPublisher.class),
+        mock(CapabilitiesModuleEventPublisher.class));
+    }
+
+    @Bean
+    public KeycloakModuleResourceCreator keycloakModuleResourceCreator() {
+      var mock = mock(KeycloakModuleResourceCreator.class);
+      when(mock.getId()).thenReturn("KeycloakModuleResourceCreator");
+      return mock;
+    }
+
+    @Bean
+    public FlowStageRepository flowStageRepository() {
+      return mock(FlowStageRepository.class);
+    }
+
+    @Bean
+    public ThreadLocalModuleStageContext threadLocalModuleStageContext() {
+      return mock(ThreadLocalModuleStageContext.class);
+    }
+
+    @Bean
+    public KongGatewayService kongGatewayService() {
+      return mock(KongGatewayService.class);
+    }
+
+    @Bean
+    public OkHttpClient okHttpClient() {
+      return mock(OkHttpClient.class);
+    }
+
+    @Bean
+    public KongConfigurationProperties kongConfigurationProperties() {
+      return mock(KongConfigurationProperties.class);
+    }
+
+    @Bean
+    public RetryConfigurationProperties retryConfigurationProperties() {
+      return RetryConfigurationProperties.builder().build();
+    }
+
+    @Bean
+    public Contract contract() {
+      return mock(Contract.class);
+    }
+
+    @Bean
+    public Encoder encoder() {
+      return mock(Encoder.class);
+    }
+
+    @Bean
+    public Decoder decoder() {
+      return mock(Decoder.class);
+    }
+  }
+}

--- a/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementEnabledTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kong/KongRouteManagementEnabledTest.java
@@ -35,12 +35,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(properties = {"routemanagement.enable=true"})
 @ContextConfiguration(classes = {KongRouteManagementEnabledTest.KongConfigExt.class,
   KongRouteManagementEnabledTest.TestConfig.class})
-public class KongRouteManagementEnabledTest {
+class KongRouteManagementEnabledTest {
 
   @Autowired private FolioModuleEntitleFlowFactory flowFactory;
 
   @Test
-  public void testFlowFactory() {
+  void testFlowFactory() {
     var flow = flowFactory.createModuleFlow("123", FlowExecutionStrategy.IGNORE_ON_ERROR, Map.of());
     // Check that we have a ResourceCreatorParallelStage resource creator stage that does both Kong routes
     // and Keycloak resources creation, but not a separate KeycloakModuleResourceCreator stage
@@ -53,6 +53,7 @@ public class KongRouteManagementEnabledTest {
   public static class KongConfigExt extends KongConfiguration {
 
     @Bean(name = "folioKongAdminClient")
+    @Override
     public KongAdminClient folioKongIntegrationClient(okhttp3.OkHttpClient okHttpClient,
       KongConfigurationProperties properties, Contract contract, Encoder encoder, Decoder decoder,
       RetryConfigurationProperties retryConfig, ThreadLocalModuleStageContext threadLocalModuleStageContext) {


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MGRENTITLE-81

Introduce feature toggle for disabling Kong route management for entitled/unentitled modules. Route management for modules will now be part of mgr-applications, where routes will be created in tenant-independent way.

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
