### PR TITLE
MGRENTITLE-101 Extend GET /entitlements with ability to retrieve tenant entitlements by tenant name via additional "tenant" query parameter

### DIFF
--- a/src/main/java/org/folio/entitlement/controller/EntitlementController.java
+++ b/src/main/java/org/folio/entitlement/controller/EntitlementController.java
@@ -23,8 +23,9 @@ public class EntitlementController extends BaseController implements Entitlement
   private final EntitlementService entitlementService;
 
   @Override
-  public ResponseEntity<Entitlements> findByQuery(String query, Boolean includeModules, Integer limit, Integer offset) {
-    var entitlements = entitlementService.findByQuery(query, includeModules, limit, offset);
+  public ResponseEntity<Entitlements> findByQueryOrTenantName(String query, String tenant, Boolean includeModules,
+    Integer limit, Integer offset, String token) {
+    var entitlements = entitlementService.findByQueryOrTenantName(query, tenant, includeModules, limit, offset, token);
     return ResponseEntity.ok(new Entitlements()
       .totalRecords(entitlements.getTotalRecords())
       .entitlements(entitlements.getRecords()));

--- a/src/main/java/org/folio/entitlement/domain/entity/EntitlementEntity.java
+++ b/src/main/java/org/folio/entitlement/domain/entity/EntitlementEntity.java
@@ -12,12 +12,15 @@ import java.util.UUID;
 import lombok.Data;
 import org.folio.common.utils.SemverUtils;
 import org.folio.entitlement.domain.entity.key.EntitlementKey;
+import org.springframework.data.domain.Sort;
 
 @Data
 @Entity
 @Table(name = "entitlement")
 @IdClass(EntitlementKey.class)
 public class EntitlementEntity implements Serializable {
+
+  public static final Sort DEFAULT_SORT = Sort.by(Sort.Direction.ASC, "tenantId", "applicationId");
 
   @Serial private static final long serialVersionUID = 1717674444565778201L;
 

--- a/src/main/java/org/folio/entitlement/service/EntitlementCrudService.java
+++ b/src/main/java/org/folio/entitlement/service/EntitlementCrudService.java
@@ -1,6 +1,7 @@
 package org.folio.entitlement.service;
 
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 
 import java.util.List;
@@ -38,8 +39,10 @@ public class EntitlementCrudService {
    */
   @Transactional(readOnly = true)
   public ResultList<Entitlement> findByQuery(String cqlQuery, Boolean includeModules, Integer limit, Integer offset) {
-    var pageable = OffsetRequest.of(offset, limit);
-    var appInstallEntities = entitlementRepository.findByCql(cqlQuery, pageable);
+    var appInstallEntities = isNotBlank(cqlQuery)
+      ? entitlementRepository.findByCql(cqlQuery, OffsetRequest.of(offset, limit))
+      : entitlementRepository.findAll(OffsetRequest.of(offset, limit, EntitlementEntity.DEFAULT_SORT));
+
     var tenantEntitlements = mapItems(appInstallEntities.toList(),
       isTrue(includeModules)
         ? entity -> entitlementMapper.mapWithModules(entity, fetchEntitlementModules(entity))

--- a/src/main/java/org/folio/entitlement/service/flow/ApplicationFlowService.java
+++ b/src/main/java/org/folio/entitlement/service/flow/ApplicationFlowService.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.groupingBy;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 
 import java.util.Collection;
@@ -67,7 +68,11 @@ public class ApplicationFlowService {
    */
   @Transactional(readOnly = true)
   public SearchResult<ApplicationFlow> find(String query, Integer limit, Integer offset) {
-    var foundEntities = applicationFlowRepository.findByCql(query, OffsetRequest.of(offset, limit));
+    var pageable = OffsetRequest.of(offset, limit);
+    var foundEntities = isNotBlank(query)
+      ? applicationFlowRepository.findByCql(query, pageable)
+      : applicationFlowRepository.findAll(pageable);
+
     var mappedRecords = foundEntities.map(applicationFlowMapper::map).getContent();
     return SearchResult.of((int) foundEntities.getTotalElements(), mappedRecords);
   }

--- a/src/main/java/org/folio/entitlement/service/flow/FlowService.java
+++ b/src/main/java/org/folio/entitlement/service/flow/FlowService.java
@@ -1,6 +1,7 @@
 package org.folio.entitlement.service.flow;
 
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 
 import java.util.UUID;
@@ -37,7 +38,11 @@ public class FlowService {
    */
   @Transactional(readOnly = true)
   public SearchResult<Flow> find(String query, Integer limit, Integer offset) {
-    var foundEntities = flowRepository.findByCql(query, OffsetRequest.of(offset, limit));
+    var pageable = OffsetRequest.of(offset, limit);
+    var foundEntities = isNotBlank(query)
+      ? flowRepository.findByCql(query, pageable)
+      : flowRepository.findAll(pageable);
+
     var flowIds = mapItems(foundEntities.getContent(), FlowEntity::getId);
     var applicationFlowIdsMap = applicationFlowService.findByFlowIds(flowIds);
 

--- a/src/main/resources/swagger.api/mgr-tenant-entitlements.yaml
+++ b/src/main/resources/swagger.api/mgr-tenant-entitlements.yaml
@@ -70,7 +70,7 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
     get:
-      operationId: findByQuery
+      operationId: findByQueryOrTenantName
       description: |
         Retrieves all the entitlement using query tools (CQL query, limit and offset parameters).
         Basic authorization is required to perform request (e.g. Authorization=Basic dXNlcjp1c2Vy).
@@ -78,9 +78,11 @@ paths:
         - entitlement
       parameters:
         - $ref: '#/components/parameters/cql-query'
+        - $ref: '#/components/parameters/query-tenant-name'
         - $ref: '#/components/parameters/query-includeModules'
         - $ref: '#/components/parameters/query-limit'
         - $ref: '#/components/parameters/query-offset'
+        - $ref: '#/components/parameters/x-okapi-token'
       responses:
         '200':
           description: "A list with created tenant entitlements"
@@ -118,29 +120,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/extendedEntitlements'
-        '400':
-          $ref: '#/components/responses/badRequestResponse'
-        '500':
-          $ref: '#/components/responses/internalServerErrorResponse'
-
-  /entitlements/{tenantId}:
-    get:
-      operationId: findEntitlementsByTenantId
-      description: List of tenant entitlements
-      tags:
-        - entitlement
-      parameters:
-        - $ref: '#/components/parameters/path-tenant-id'
-        - $ref: '#/components/parameters/query-includeModules'
-        - $ref: '#/components/parameters/query-limit'
-        - $ref: '#/components/parameters/query-offset'
-      responses:
-        '200':
-          description: "A list with created tenant entitlements"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/entitlements'
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '500':
@@ -471,7 +450,13 @@ components:
       description: A CQL query string with search conditions.
       schema:
         type: string
-        default: cql.allRecords=1
+    query-tenant-name:
+      in: query
+      required: false
+      name: tenant
+      description: Tenant name to filter by.
+      schema:
+        type: string
     x-okapi-token:
       name: x-okapi-token
       in: header

--- a/src/test/java/org/folio/entitlement/controller/RoutesPrefixControllerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/RoutesPrefixControllerTest.java
@@ -40,7 +40,8 @@ class RoutesPrefixControllerTest {
   @Test
   void get_positive() throws Exception {
     var cqlQuery = String.format("tenantId=%s", TENANT_ID);
-    when(entitlementService.findByQuery(cqlQuery, false, 10, 0)).thenReturn(asSinglePage(entitlement()));
+    when(entitlementService.findByQueryOrTenantName(cqlQuery, null, false, 10, 0, OKAPI_TOKEN))
+      .thenReturn(asSinglePage(entitlement()));
 
     mockMvc.perform(get("/mgr-tenant-entitlements/entitlements")
         .param("query", cqlQuery)

--- a/src/test/java/org/folio/entitlement/service/EntitlementCrudServiceTest.java
+++ b/src/test/java/org/folio/entitlement/service/EntitlementCrudServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.folio.common.domain.model.OffsetRequest;
+import org.folio.entitlement.domain.entity.EntitlementEntity;
 import org.folio.entitlement.domain.entity.key.EntitlementKey;
 import org.folio.entitlement.domain.model.EntitlementRequest;
 import org.folio.entitlement.mapper.ApplicationDependencyMapper;
@@ -58,6 +59,21 @@ class EntitlementCrudServiceTest {
     when(entitlementMapper.map(entity)).thenReturn(entitlement(TENANT_ID, APPLICATION_ID));
 
     var actual = service.findByQuery(cqlQuery, false, limit, offset);
+
+    assertThat(actual).isEqualTo(asSinglePage(entitlement(TENANT_ID, APPLICATION_ID)));
+  }
+
+  @Test
+  void findByQuery_positive_emptyQuery() {
+    var offset = 0;
+    var limit = 10;
+    var offsetRequest = OffsetRequest.of(offset, limit, EntitlementEntity.DEFAULT_SORT);
+    var entity = entitlementEntity();
+
+    when(entitlementRepository.findAll(offsetRequest)).thenReturn(new PageImpl<>(singletonList(entity)));
+    when(entitlementMapper.map(entity)).thenReturn(entitlement(TENANT_ID, APPLICATION_ID));
+
+    var actual = service.findByQuery(null, false, limit, offset);
 
     assertThat(actual).isEqualTo(asSinglePage(entitlement(TENANT_ID, APPLICATION_ID)));
   }


### PR DESCRIPTION
## Purpose
Extend `GET /entitlements` API method to retrieve all entitled applications by tenant name. One of the expected applications of the methods will be in sidecars to get a list of tenant enabled modules. 
US: [MGRENTITLE-101](https://folio-org.atlassian.net/browse/MGRENTITLE-101)

## Approach
* add new parameter called `tenant` to `GET /entitlements` API method
* if `tenant` is provided in the request, obtain tenant info from Tenant Manager and use tenant id to query entitlements
* prohibit usage of both `tenant` and `query` parameters in the request
* remove non-implemented method: `GET /entitlements/{tenantId} `

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
