### PR TITLE
MGRENTITLE-118 Not able to entitle application due to dependency issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## Version `4.0.0` (TBD)
+* Not able to entitle application due to dependency issue (MGRENTITLE-118)
 * mgr-tenant-entitlements does not check the cross-application module dependencies as expected (MGRENTITLE-113)
 * Introduce optional application dependencies (MGRAPPS-57)
 ---

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ docker run \
 
 ### Validators environment variables
 
-| Name                                   | Default value | Required | Description                                                                                                                                                                                                                                                     |
-|:---------------------------------------|:--------------|:--------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| VALIDATION_INTERFACE_INTEGRITY_ENABLED | true          |  false   | Configure a behavior of validation. If false, Interface-Integrity validator should not be executed                                                                                                                                                              |
-| VALIDATION_INTERFACE_COLLECTOR_MODE    | combined      |  false   | Defines how required / provided interfaces collected from application descriptors for validation. `scoped` means the interfaces collected for each application and its dependencies, `combined` means the interfaces collected from all applications altogether |
+| Name                                                     | Default value | Required | Description                                                                                                                                                                                                                                                     |
+|:---------------------------------------------------------|:--------------|:--------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| VALIDATION_INTERFACE_INTEGRITY_ENABLED                   | true          |  false   | Configure a behavior of validation. If false, Interface-Integrity validator should not be executed                                                                                                                                                              |
+| VALIDATION_INTERFACE_COLLECTOR_MODE                      | combined      |  false   | Defines how required / provided interfaces collected from application descriptors for validation. `scoped` means the interfaces collected for each application and its dependencies, `combined` means the interfaces collected from all applications altogether |
+| VALIDATION_INTERFACE_COLLECTOR_EXCLUDE_ENTITLED_REQUIRED | true          |  false   | If set to `true` required interfaces of entitled applications won't be collected                                                                                                                                                                                |
 
 
 ### Kafka environment variables

--- a/src/main/java/org/folio/entitlement/TenantEntitlementApplication.java
+++ b/src/main/java/org/folio/entitlement/TenantEntitlementApplication.java
@@ -6,6 +6,7 @@ import org.folio.security.EnableMgrSecurity;
 import org.folio.spring.cql.JpaCqlConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Import;
 
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Import;
 @SpringBootApplication
 @Import({JpaCqlConfiguration.class, TransactionHelper.class})
 @EnableMgrSecurity
+@ConfigurationPropertiesScan
 public class TenantEntitlementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/folio/entitlement/service/ApplicationDependencyValidatorService.java
+++ b/src/main/java/org/folio/entitlement/service/ApplicationDependencyValidatorService.java
@@ -11,6 +11,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -49,17 +50,18 @@ public class ApplicationDependencyValidatorService {
 
     var applicationDescriptors = applicationTreeLoader.load(request);
 
-    validateDescriptors(applicationDescriptors);
+    validateDescriptors(applicationDescriptors, tenantId);
   }
 
-  public void validateDescriptors(List<ApplicationDescriptor> descriptors) {
+  public void validateDescriptors(List<ApplicationDescriptor> descriptors, UUID tenantId) {
     if (isEmpty(descriptors)) {
       throw new RequestValidationException("No application descriptors provided", "descriptors", null);
     }
-    log.info("Validating dependencies between application descriptors: appIds = [{}]",
-      () -> descriptors.stream().map(ApplicationDescriptor::getId).collect(Collectors.joining(", ")));
+    log.info("Validating dependencies between application descriptors: appIds = [{}], tenantId = {}",
+      () -> descriptors.stream().map(ApplicationDescriptor::getId).collect(Collectors.joining(", ")),
+      () -> tenantId);
 
-    var missingInterfaces = interfaceCollector.collectRequiredAndProvided(descriptors)
+    var missingInterfaces = interfaceCollector.collectRequiredAndProvided(descriptors, tenantId)
       .flatMap(this::findMissingInterfaces)
       .collect(toSet());
 

--- a/src/main/java/org/folio/entitlement/service/ApplicationInterfaceCollector.java
+++ b/src/main/java/org/folio/entitlement/service/ApplicationInterfaceCollector.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -22,7 +23,7 @@ public interface ApplicationInterfaceCollector {
    * @param descriptors the list of application descriptors
    * @return a stream of {@link RequiredProvidedInterfaces} containing required and provided interfaces
    */
-  Stream<RequiredProvidedInterfaces> collectRequiredAndProvided(List<ApplicationDescriptor> descriptors);
+  Stream<RequiredProvidedInterfaces> collectRequiredAndProvided(List<ApplicationDescriptor> descriptors, UUID tenantId);
 
   record RequiredProvidedInterfaces(Set<InterfaceItem> required, Map<String, Set<InterfaceItem>> provided) {
 

--- a/src/main/java/org/folio/entitlement/service/CombinedApplicationInterfaceCollector.java
+++ b/src/main/java/org/folio/entitlement/service/CombinedApplicationInterfaceCollector.java
@@ -2,33 +2,46 @@ package org.folio.entitlement.service;
 
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.folio.common.utils.CollectionUtils.mapItems;
+import static org.folio.common.utils.CollectionUtils.mapItemsToSet;
 import static org.folio.common.utils.CollectionUtils.toStream;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.common.domain.model.ApplicationDescriptor;
+import org.folio.entitlement.domain.dto.Entitlement;
+import org.folio.entitlement.service.configuration.ApplicationInterfaceCollectorProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Log4j2
 @Component
+@RequiredArgsConstructor
 @ConditionalOnProperty(name = "application.validation.interface-integrity.interface-collector.mode",
   havingValue = "combined")
 public class CombinedApplicationInterfaceCollector implements ApplicationInterfaceCollector {
 
+  private final EntitlementCrudService entitlementCrudService;
+  private final ApplicationInterfaceCollectorProperties collectorProperties;
+
   @Override
-  public Stream<RequiredProvidedInterfaces> collectRequiredAndProvided(List<ApplicationDescriptor> descriptors) {
+  public Stream<RequiredProvidedInterfaces> collectRequiredAndProvided(List<ApplicationDescriptor> descriptors,
+    UUID tenantId) {
     if (isEmpty(descriptors)) {
       return Stream.empty();
     }
 
     log.debug("Reading required/provided interfaces from the descriptors [combined mode]...");
+    var entitledApplicationIds = getEntitledApplicationIds(descriptors, tenantId);
 
     var result = toStream(descriptors)
-      .map(ApplicationInterfaceCollectorUtils::populateRequiredAndProvidedFromApp)
+      .map(descriptor -> populateInterfaces(descriptor, entitledApplicationIds))
       .reduce(RequiredProvidedInterfaces.empty(), RequiredProvidedInterfaces::merge);
 
     log.debug("Interface summary: required = {}, provided = [{}]", result::required,
@@ -38,5 +51,19 @@ public class CombinedApplicationInterfaceCollector implements ApplicationInterfa
         .collect(joining(", ")));
 
     return Stream.of(result);
+  }
+
+  private Set<String> getEntitledApplicationIds(List<ApplicationDescriptor> descriptors, UUID tenantId) {
+    var entitlements = entitlementCrudService.findByApplicationIds(tenantId,
+      mapItems(descriptors, ApplicationDescriptor::getId));
+    return mapItemsToSet(entitlements, Entitlement::getApplicationId);
+  }
+
+  private RequiredProvidedInterfaces populateInterfaces(ApplicationDescriptor descriptor,
+    Set<String> entitledApplicationIds) {
+    return (collectorProperties.getRequired().isExcludeEntitled()
+      && entitledApplicationIds.contains(descriptor.getId()))
+      ? ApplicationInterfaceCollectorUtils.populateProvidedFromApp(descriptor)
+      : ApplicationInterfaceCollectorUtils.populateRequiredAndProvidedFromApp(descriptor);
   }
 }

--- a/src/main/java/org/folio/entitlement/service/EntitlementCrudService.java
+++ b/src/main/java/org/folio/entitlement/service/EntitlementCrudService.java
@@ -85,6 +85,19 @@ public class EntitlementCrudService {
   }
 
   /**
+   * Retrieve tenant entitlements by application identifiers.
+   *
+   * @param tenantId       - tenant identifier as {@link UUID} object
+   * @param applicationIds - list with application identifiers
+   * @return list with found tenant {@link Entitlement} objects
+   */
+  @Transactional(readOnly = true)
+  public List<Entitlement> findByApplicationIds(UUID tenantId, List<String> applicationIds) {
+    var entitlementEntities = entitlementRepository.findByTenantIdAndApplicationIdIn(tenantId, applicationIds);
+    return mapItems(entitlementEntities, entitlementMapper::map);
+  }
+
+  /**
    * Saves entitlement.
    *
    * @param entitlement - entitlement as {@link Entitlement}

--- a/src/main/java/org/folio/entitlement/service/configuration/ApplicationInterfaceCollectorProperties.java
+++ b/src/main/java/org/folio/entitlement/service/configuration/ApplicationInterfaceCollectorProperties.java
@@ -1,0 +1,15 @@
+package org.folio.entitlement.service.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+@ConfigurationProperties(prefix = "application.validation.interface-integrity.interface-collector")
+public class ApplicationInterfaceCollectorProperties {
+
+  @NestedConfigurationProperty
+  private CollectedInterfaceSettings required = new CollectedInterfaceSettings();
+}

--- a/src/main/java/org/folio/entitlement/service/configuration/CollectedInterfaceSettings.java
+++ b/src/main/java/org/folio/entitlement/service/configuration/CollectedInterfaceSettings.java
@@ -1,0 +1,11 @@
+package org.folio.entitlement.service.configuration;
+
+import lombok.Data;
+
+@Data
+public class CollectedInterfaceSettings {
+
+  private static boolean DEFAULT_EXCLUDE_ENTITLED = true;
+
+  private boolean excludeEntitled = DEFAULT_EXCLUDE_ENTITLED;
+}

--- a/src/main/java/org/folio/entitlement/service/configuration/CollectedInterfaceSettings.java
+++ b/src/main/java/org/folio/entitlement/service/configuration/CollectedInterfaceSettings.java
@@ -5,7 +5,7 @@ import lombok.Data;
 @Data
 public class CollectedInterfaceSettings {
 
-  private static boolean DEFAULT_EXCLUDE_ENTITLED = true;
+  private static final boolean DEFAULT_EXCLUDE_ENTITLED = true;
 
   private boolean excludeEntitled = DEFAULT_EXCLUDE_ENTITLED;
 }

--- a/src/main/java/org/folio/entitlement/service/validator/InterfaceIntegrityValidator.java
+++ b/src/main/java/org/folio/entitlement/service/validator/InterfaceIntegrityValidator.java
@@ -26,7 +26,8 @@ public class InterfaceIntegrityValidator extends DatabaseLoggingStage<CommonStag
       return;
     }
     var applicationDescriptors = context.getApplicationDescriptors();
-    dependencyValidatorService.validateDescriptors(applicationDescriptors);
+    var tenantId = context.getEntitlementRequest().getTenantId();
+    dependencyValidatorService.validateDescriptors(applicationDescriptors, tenantId);
   }
 
   @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -155,6 +155,8 @@ application:
       enabled: ${VALIDATION_INTERFACE_INTEGRITY_ENABLED:true}
       interface-collector:
         mode: ${VALIDATION_INTERFACE_COLLECTOR_MODE:combined}
+        required:
+          exclude-entitled: ${VALIDATION_INTERFACE_COLLECTOR_EXCLUDE_ENTITLED_REQUIRED:true}
 
 folio:
   jpa:

--- a/src/test/java/org/folio/entitlement/controller/ApiExceptionHandlerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/ApiExceptionHandlerTest.java
@@ -58,9 +58,9 @@ import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,8 +79,8 @@ class ApiExceptionHandlerTest {
   private final FlowEngine flowEngine = singleThreadFlowEngine("api-exception-handler-fe", false);
 
   @Autowired private MockMvc mockMvc;
-  @MockBean private TestService testService;
-  @MockBean private FlowStageService flowStageService;
+  @MockitoBean private TestService testService;
+  @MockitoBean private FlowStageService flowStageService;
 
   @Test
   void handleUnsupportedOperationException_positive() throws Exception {

--- a/src/test/java/org/folio/entitlement/controller/EntitlementControllerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/EntitlementControllerTest.java
@@ -52,14 +52,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
 @Import({ControllerTestConfiguration.class, EntitlementController.class})
-@MockBean(FlowStageService.class)
+@MockitoBean(types = FlowStageService.class)
 @WebMvcTest(EntitlementController.class)
 @EnableKeycloakSecurity
 @TestPropertySource(properties = "application.router.path-prefix=/")
@@ -70,9 +70,9 @@ class EntitlementControllerTest {
 
   @Autowired private MockMvc mockMvc;
   @Mock private JsonWebToken jsonWebToken;
-  @MockBean private EntitlementService entitlementService;
-  @MockBean private KeycloakAuthClient authClient;
-  @MockBean private JsonWebTokenParser jsonWebTokenParser;
+  @MockitoBean private EntitlementService entitlementService;
+  @MockitoBean private KeycloakAuthClient authClient;
+  @MockitoBean private JsonWebTokenParser jsonWebTokenParser;
 
   @Test
   void create_positive() throws Exception {

--- a/src/test/java/org/folio/entitlement/controller/EntitlementModuleControllerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/EntitlementModuleControllerTest.java
@@ -21,22 +21,22 @@ import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
 @EnableKeycloakSecurity
-@MockBean(FlowStageService.class)
+@MockitoBean(types = FlowStageService.class)
 @WebMvcTest(EntitlementModuleController.class)
 @Import({ControllerTestConfiguration.class, EntitlementModuleController.class, FeignAutoConfiguration.class})
 @TestPropertySource(properties = "application.router.path-prefix=/")
 class EntitlementModuleControllerTest {
 
   @Autowired private MockMvc mockMvc;
-  @MockBean private EntitlementModuleService entitlementService;
+  @MockitoBean private EntitlementModuleService entitlementService;
 
   @Test
   void get_positive() throws Exception {

--- a/src/test/java/org/folio/entitlement/controller/EntitlementValidationControllerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/EntitlementValidationControllerTest.java
@@ -34,17 +34,16 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
 @Import({ControllerTestConfiguration.class,
   EntitlementValidationController.class,
   EntitlementTypeConverters.FromString.class})
-@MockBean(FlowStageService.class)
-@MockBean(KeycloakAuthClient.class)
+@MockitoBean(types = {FlowStageService.class, KeycloakAuthClient.class})
 @WebMvcTest(EntitlementValidationController.class)
 @EnableKeycloakSecurity
 @TestPropertySource(properties = "application.router.path-prefix=/")
@@ -55,8 +54,8 @@ class EntitlementValidationControllerTest {
 
   @Autowired private MockMvc mockMvc;
   @Mock private JsonWebToken jsonWebToken;
-  @MockBean private JsonWebTokenParser jsonWebTokenParser;
-  @MockBean private EntitlementValidationService validationService;
+  @MockitoBean private JsonWebTokenParser jsonWebTokenParser;
+  @MockitoBean private EntitlementValidationService validationService;
 
   @ParameterizedTest
   @EnumSource(EntitlementType.class)

--- a/src/test/java/org/folio/entitlement/controller/FlowControllerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/FlowControllerTest.java
@@ -26,9 +26,9 @@ import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
@@ -38,9 +38,9 @@ import org.springframework.test.web.servlet.MockMvc;
 class  FlowControllerTest {
 
   @Autowired private MockMvc mockMvc;
-  @MockBean private FlowService flowService;
-  @MockBean private ApplicationFlowService applicationFlowService;
-  @MockBean private FlowStageService flowStageService;
+  @MockitoBean private FlowService flowService;
+  @MockitoBean private ApplicationFlowService applicationFlowService;
+  @MockitoBean private FlowStageService flowStageService;
 
   @Test
   void findFlows_positive() throws Exception {

--- a/src/test/java/org/folio/entitlement/controller/RoutesPrefixControllerTest.java
+++ b/src/test/java/org/folio/entitlement/controller/RoutesPrefixControllerTest.java
@@ -20,22 +20,22 @@ import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
 @EnableKeycloakSecurity
 @Import({ControllerTestConfiguration.class, EntitlementController.class, FeignAutoConfiguration.class})
-@MockBean(FlowStageService.class)
+@MockitoBean(types = FlowStageService.class)
 @WebMvcTest(EntitlementController.class)
 @TestPropertySource(properties = "application.router.path-prefix=mgr-tenant-entitlements")
 class RoutesPrefixControllerTest {
 
   @Autowired private MockMvc mockMvc;
-  @MockBean private EntitlementService entitlementService;
+  @MockitoBean private EntitlementService entitlementService;
 
   @Test
   void get_positive() throws Exception {

--- a/src/test/java/org/folio/entitlement/service/CombinedApplicationInterfaceCollectorTest.java
+++ b/src/test/java/org/folio/entitlement/service/CombinedApplicationInterfaceCollectorTest.java
@@ -1,0 +1,213 @@
+package org.folio.entitlement.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.common.utils.CollectionUtils.mapItems;
+import static org.folio.entitlement.support.TestConstants.TENANT_ID;
+import static org.folio.entitlement.support.TestUtils.readApplicationDescriptor;
+import static org.folio.entitlement.support.TestValues.itfItem;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.folio.common.domain.model.ApplicationDescriptor;
+import org.folio.entitlement.domain.dto.Entitlement;
+import org.folio.entitlement.service.ApplicationInterfaceCollector.RequiredProvidedInterfaces;
+import org.folio.entitlement.service.configuration.ApplicationInterfaceCollectorProperties;
+import org.folio.entitlement.service.configuration.CollectedInterfaceSettings;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class CombinedApplicationInterfaceCollectorTest {
+
+  private static final Entitlement ENTITLEMENT_APP1 =
+    new Entitlement().applicationId("folio-app1-1.0.0").tenantId(TENANT_ID);
+  private static final Entitlement ENTITLEMENT_APP2 =
+    new Entitlement().applicationId("folio-app2-1.0.0").tenantId(TENANT_ID);
+  private static final Entitlement ENTITLEMENT_APP3 =
+    new Entitlement().applicationId("folio-app3-1.0.0").tenantId(TENANT_ID);
+
+  private static final ApplicationDescriptor APP_DESCRIPTOR1 =
+    readApplicationDescriptor("json/ic/folio-app1-full.json");
+  private static final ApplicationDescriptor APP_DESCRIPTOR2 =
+    readApplicationDescriptor("json/ic/folio-app2-full.json");
+  private static final ApplicationDescriptor APP_DESCRIPTOR3 =
+    readApplicationDescriptor("json/ic/folio-app3-full.json");
+
+  private static final List<RequiredProvidedInterfaces> REQUIRED_PROVIDED_INTERFACES = List.of(
+    new RequiredProvidedInterfaces(
+      Set.of(
+        itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0"),
+        itfItem("folio-module1-api", "1.0", "folio-app2-1.0.0"),
+        itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0"),
+        itfItem("folio-module2-api", "1.0", "folio-app3-1.0.0")
+      ),
+      Map.of(
+        "folio-module3-api",
+        Set.of(itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0")),
+        "folio-module2-api",
+        Set.of(itfItem("folio-module2-api", "1.0", "folio-app2-1.0.0")),
+        "folio-module1-api",
+        Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0"))
+      )
+    )
+  );
+
+  @Mock private EntitlementCrudService entitlementCrudService;
+
+  @Nested
+  @DisplayName("CombinedApplicationInterfaceCollector::RequiredInterfacesIncluded")
+  class IncludeRequiredInterfacesOfInstalledAppsTest {
+
+    private CombinedApplicationInterfaceCollector collector;
+
+    @BeforeEach
+    void setUp() {
+      var required = new CollectedInterfaceSettings();
+      required.setExcludeEntitled(false);
+      var properties = new ApplicationInterfaceCollectorProperties();
+      properties.setRequired(required);
+
+      this.collector = new CombinedApplicationInterfaceCollector(entitlementCrudService, properties);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("requiredInterfacesIncludedDataProvider")
+    void collectRequiredAndProvided_positive(@SuppressWarnings("unused") String testName,
+      List<ApplicationDescriptor> descriptors, List<Entitlement> entitlements,
+      List<RequiredProvidedInterfaces> expected) {
+      when(entitlementCrudService.findByApplicationIds(TENANT_ID, mapItems(descriptors, ApplicationDescriptor::getId)))
+        .thenReturn(entitlements);
+
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+
+      assertThat(result).hasSameElementsAs(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void collectRequiredAndProvided_positive_emptyDescriptorList(List<ApplicationDescriptor> descriptors) {
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+      assertThat(result).isEmpty();
+    }
+
+    private static Stream<Arguments> requiredInterfacesIncludedDataProvider() {
+      return Stream.of(
+        arguments("nothing entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          emptyList(),
+          REQUIRED_PROVIDED_INTERFACES
+        ),
+        arguments("app1/app2 entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2),
+          REQUIRED_PROVIDED_INTERFACES
+        ),
+        arguments("all apps entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2, ENTITLEMENT_APP3),
+          REQUIRED_PROVIDED_INTERFACES
+        )
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("CombinedApplicationInterfaceCollector::RequiredInterfacesExcluded")
+  class ExcludeRequiredInterfacesOfInstalledAppsTest {
+
+    private CombinedApplicationInterfaceCollector collector;
+
+    @BeforeEach
+    void setUp() {
+      var required = new CollectedInterfaceSettings();
+      required.setExcludeEntitled(true);
+      var properties = new ApplicationInterfaceCollectorProperties();
+      properties.setRequired(required);
+
+      this.collector = new CombinedApplicationInterfaceCollector(entitlementCrudService, properties);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("requiredInterfacesExcludedDataProvider")
+    void collectRequiredAndProvided_positive(@SuppressWarnings("unused") String testName,
+      List<ApplicationDescriptor> descriptors, List<Entitlement> entitlements,
+      List<RequiredProvidedInterfaces> expected) {
+      when(entitlementCrudService.findByApplicationIds(TENANT_ID, mapItems(descriptors, ApplicationDescriptor::getId)))
+        .thenReturn(entitlements);
+
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+
+      assertThat(result).hasSameElementsAs(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void collectRequiredAndProvided_positive_emptyDescriptorList(List<ApplicationDescriptor> descriptors) {
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+      assertThat(result).isEmpty();
+    }
+
+    private static Stream<Arguments> requiredInterfacesExcludedDataProvider() {
+      return Stream.of(
+        arguments("nothing entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          emptyList(),
+          REQUIRED_PROVIDED_INTERFACES
+        ),
+        arguments("app1/app2 entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2),
+          List.of(
+            new RequiredProvidedInterfaces(
+              Set.of(
+                itfItem("folio-module2-api", "1.0", "folio-app3-1.0.0"),
+                itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0")
+              ),
+              Map.of(
+                "folio-module1-api",
+                Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0")),
+                "folio-module2-api",
+                Set.of(itfItem("folio-module2-api", "1.0", "folio-app2-1.0.0")),
+                "folio-module3-api",
+                Set.of(itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0"))
+              )
+            )
+          )
+        ),
+        arguments("all apps entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2, ENTITLEMENT_APP3),
+          List.of(
+            new RequiredProvidedInterfaces(
+              emptySet(),
+              Map.of(
+                "folio-module1-api",
+                Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0")),
+                "folio-module2-api",
+                Set.of(itfItem("folio-module2-api", "1.0", "folio-app2-1.0.0")),
+                "folio-module3-api",
+                Set.of(itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0"))
+              )
+            )
+          )
+        )
+      );
+    }
+  }
+}

--- a/src/test/java/org/folio/entitlement/service/ReinstallServiceTest.java
+++ b/src/test/java/org/folio/entitlement/service/ReinstallServiceTest.java
@@ -70,14 +70,18 @@ class ReinstallServiceTest {
     assertThat(result.getEntitlements()).hasSize(4);
     assertThat(result.getErrors()).hasSize(4);
     assertThat(result.getEntitlements()).containsAll(List.of("m1", "m4", "m1_2", "m4_2"));
-    assertThat(result.getErrors().get(0)).startsWith(
-      "Error re-installing module m2 - RuntimeException Test Exception.\njava.lang.RuntimeException: Test Exception");
-    assertThat(result.getErrors().get(1)).startsWith(
-      "Error re-installing module m3 - RuntimeException Test Exception.\njava.lang.RuntimeException: Test Exception");
-    assertThat(result.getErrors().get(2)).startsWith(
-      "Error re-installing module m2_2 - RuntimeException Test Exception.\njava.lang.RuntimeException: Test Exception");
-    assertThat(result.getErrors().get(3)).startsWith(
-      "Error re-installing module m3_2 - RuntimeException Test Exception.\njava.lang.RuntimeException: Test Exception");
+    assertThat(result.getErrors().get(0))
+      .startsWith("Error re-installing module m2 - RuntimeException Test Exception.")
+      .contains("java.lang.RuntimeException: Test Exception");
+    assertThat(result.getErrors().get(1))
+      .startsWith("Error re-installing module m3 - RuntimeException Test Exception.")
+      .contains("java.lang.RuntimeException: Test Exception");
+    assertThat(result.getErrors().get(2))
+      .startsWith("Error re-installing module m2_2 - RuntimeException Test Exception.")
+      .contains("java.lang.RuntimeException: Test Exception");
+    assertThat(result.getErrors().get(3))
+      .startsWith("Error re-installing module m3_2 - RuntimeException Test Exception.")
+      .contains("java.lang.RuntimeException: Test Exception");
   }
 
   @Test
@@ -98,10 +102,12 @@ class ReinstallServiceTest {
     assertThat(result.getEntitlements()).hasSize(2);
     assertThat(result.getErrors()).hasSize(2);
     assertThat(result.getEntitlements()).containsAll(List.of("m1", "m4"));
-    assertThat(result.getErrors().get(0)).startsWith(
-      "Error re-installing module m2 - RuntimeException Test Exception.\njava.lang.RuntimeException: Test Exception");
-    assertThat(result.getErrors().get(1)).startsWith(
-      "Error re-installing module m3 - RuntimeException Test Exception.\njava.lang.RuntimeException: Test Exception");
+    assertThat(result.getErrors().get(0))
+      .startsWith("Error re-installing module m2 - RuntimeException Test Exception.")
+      .contains("java.lang.RuntimeException: Test Exception");
+    assertThat(result.getErrors().get(1))
+      .startsWith("Error re-installing module m3 - RuntimeException Test Exception.")
+      .contains("java.lang.RuntimeException: Test Exception");
   }
 
   private ApplicationDescriptor mockModuleData(String appId, List<String> modules) {

--- a/src/test/java/org/folio/entitlement/service/ScopedApplicationInterfaceCollectorTest.java
+++ b/src/test/java/org/folio/entitlement/service/ScopedApplicationInterfaceCollectorTest.java
@@ -1,0 +1,214 @@
+package org.folio.entitlement.service;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.common.utils.CollectionUtils.mapItems;
+import static org.folio.entitlement.support.TestConstants.TENANT_ID;
+import static org.folio.entitlement.support.TestUtils.readApplicationDescriptor;
+import static org.folio.entitlement.support.TestValues.itfItem;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.folio.common.domain.model.ApplicationDescriptor;
+import org.folio.entitlement.domain.dto.Entitlement;
+import org.folio.entitlement.service.ApplicationInterfaceCollector.RequiredProvidedInterfaces;
+import org.folio.entitlement.service.configuration.ApplicationInterfaceCollectorProperties;
+import org.folio.entitlement.service.configuration.CollectedInterfaceSettings;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ScopedApplicationInterfaceCollectorTest {
+
+  private static final Entitlement ENTITLEMENT_APP1 =
+    new Entitlement().applicationId("folio-app1-1.0.0").tenantId(TENANT_ID);
+  private static final Entitlement ENTITLEMENT_APP2 =
+    new Entitlement().applicationId("folio-app2-1.0.0").tenantId(TENANT_ID);
+  private static final Entitlement ENTITLEMENT_APP3 =
+    new Entitlement().applicationId("folio-app3-1.0.0").tenantId(TENANT_ID);
+
+  private static final ApplicationDescriptor APP_DESCRIPTOR1 =
+    readApplicationDescriptor("json/ic/folio-app1-full.json");
+  private static final ApplicationDescriptor APP_DESCRIPTOR2 =
+    readApplicationDescriptor("json/ic/folio-app2-full.json");
+  private static final ApplicationDescriptor APP_DESCRIPTOR3 =
+    readApplicationDescriptor("json/ic/folio-app3-full.json");
+
+  private static final List<RequiredProvidedInterfaces> REQUIRED_PROVIDED_INTERFACES = List.of(
+    new RequiredProvidedInterfaces(
+      Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0")),
+      Map.of(
+        "folio-module1-api",
+        Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0"))
+      )
+    ),
+    new RequiredProvidedInterfaces(
+      Set.of(itfItem("folio-module1-api", "1.0", "folio-app2-1.0.0")),
+      Map.of(
+        "folio-module2-api",
+        Set.of(itfItem("folio-module2-api", "1.0", "folio-app2-1.0.0")),
+        "folio-module1-api",
+        Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0"))
+      )
+    ),
+    new RequiredProvidedInterfaces(
+      Set.of(
+        itfItem("folio-module2-api", "1.0", "folio-app3-1.0.0"),
+        itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0")
+      ),
+      Map.of(
+        "folio-module1-api",
+        Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0")),
+        "folio-module2-api",
+        Set.of(itfItem("folio-module2-api", "1.0", "folio-app2-1.0.0")),
+        "folio-module3-api",
+        Set.of(itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0"))
+      )
+    )
+  );
+
+  @Mock private EntitlementCrudService entitlementCrudService;
+
+  @Nested
+  @DisplayName("ScopedApplicationInterfaceCollector::RequiredInterfacesIncluded")
+  class IncludeRequiredInterfacesOfInstalledAppsTest {
+
+    private ScopedApplicationInterfaceCollector collector;
+
+    @BeforeEach
+    void setUp() {
+      var required = new CollectedInterfaceSettings();
+      required.setExcludeEntitled(false);
+      var properties = new ApplicationInterfaceCollectorProperties();
+      properties.setRequired(required);
+
+      this.collector = new ScopedApplicationInterfaceCollector(entitlementCrudService, properties);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("requiredInterfacesIncludedDataProvider")
+    void collectRequiredAndProvided_positive(@SuppressWarnings("unused") String testName,
+      List<ApplicationDescriptor> descriptors, List<Entitlement> entitlements,
+      List<RequiredProvidedInterfaces> expected) {
+      when(entitlementCrudService.findByApplicationIds(TENANT_ID, mapItems(descriptors, ApplicationDescriptor::getId)))
+        .thenReturn(entitlements);
+
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+
+      assertThat(result).hasSameElementsAs(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void collectRequiredAndProvided_positive_emptyDescriptorList(List<ApplicationDescriptor> descriptors) {
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+      assertThat(result).isEmpty();
+    }
+
+    private static Stream<Arguments> requiredInterfacesIncludedDataProvider() {
+      return Stream.of(
+        arguments("nothing entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          emptyList(),
+          REQUIRED_PROVIDED_INTERFACES
+        ),
+        arguments("app1/app2 entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2),
+          REQUIRED_PROVIDED_INTERFACES
+        ),
+        arguments("all apps entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2, ENTITLEMENT_APP3),
+          REQUIRED_PROVIDED_INTERFACES
+        )
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("ScopedApplicationInterfaceCollector::RequiredInterfacesExcluded")
+  class ExcludeRequiredInterfacesOfInstalledAppsTest {
+
+    private ScopedApplicationInterfaceCollector collector;
+
+    @BeforeEach
+    void setUp() {
+      var required = new CollectedInterfaceSettings();
+      required.setExcludeEntitled(true);
+      var properties = new ApplicationInterfaceCollectorProperties();
+      properties.setRequired(required);
+
+      this.collector = new ScopedApplicationInterfaceCollector(entitlementCrudService, properties);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("requiredInterfacesExcludedDataProvider")
+    void collectRequiredAndProvided_positive(@SuppressWarnings("unused") String testName,
+      List<ApplicationDescriptor> descriptors, List<Entitlement> entitlements,
+      List<RequiredProvidedInterfaces> expected) {
+      when(entitlementCrudService.findByApplicationIds(TENANT_ID, mapItems(descriptors, ApplicationDescriptor::getId)))
+        .thenReturn(entitlements);
+
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+
+      assertThat(result).hasSameElementsAs(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void collectRequiredAndProvided_positive_emptyDescriptorList(List<ApplicationDescriptor> descriptors) {
+      var result = collector.collectRequiredAndProvided(descriptors, TENANT_ID);
+      assertThat(result).isEmpty();
+    }
+
+    private static Stream<Arguments> requiredInterfacesExcludedDataProvider() {
+      return Stream.of(
+        arguments("nothing entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          emptyList(),
+          REQUIRED_PROVIDED_INTERFACES
+        ),
+        arguments("app1/app2 entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2),
+          List.of(
+            new ApplicationInterfaceCollector.RequiredProvidedInterfaces(
+              Set.of(
+                itfItem("folio-module2-api", "1.0", "folio-app3-1.0.0"),
+                itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0")
+              ),
+              Map.of(
+                "folio-module1-api",
+                Set.of(itfItem("folio-module1-api", "1.0", "folio-app1-1.0.0")),
+                "folio-module2-api",
+                Set.of(itfItem("folio-module2-api", "1.0", "folio-app2-1.0.0")),
+                "folio-module3-api",
+                Set.of(itfItem("folio-module3-api", "1.0", "folio-app3-1.0.0"))
+              )
+            )
+          )
+        ),
+        arguments("all apps entitled",
+          List.of(APP_DESCRIPTOR1, APP_DESCRIPTOR2, APP_DESCRIPTOR3),
+          List.of(ENTITLEMENT_APP1, ENTITLEMENT_APP2, ENTITLEMENT_APP3),
+          emptyList()
+        )
+      );
+    }
+  }
+}

--- a/src/test/java/org/folio/entitlement/service/validator/InterfaceIntegrityValidatorTest.java
+++ b/src/test/java/org/folio/entitlement/service/validator/InterfaceIntegrityValidatorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.folio.entitlement.domain.dto.EntitlementType.ENTITLE;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_APP_DESCRIPTORS;
+import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_REQUEST;
 import static org.folio.entitlement.support.TestConstants.APPLICATION_ID;
 import static org.folio.entitlement.support.TestConstants.FLOW_ID;
 import static org.folio.entitlement.support.TestConstants.OKAPI_TOKEN;
@@ -46,13 +47,15 @@ class InterfaceIntegrityValidatorTest {
   void execute_positive() {
     var applicationDescriptors = List.of(TestValues.appDescriptor());
     var stageParameters = Map.of(PARAM_APP_DESCRIPTORS, applicationDescriptors);
+    var entitlementReq =  EntitlementRequest.builder().tenantId(TENANT_ID).applications(List.of(APPLICATION_ID));
+    var flowParameters = Map.of(PARAM_REQUEST, entitlementReq);
     var stageContext = commonStageContext(FLOW_ID, emptyMap(), stageParameters);
 
     when(properties.isEnabled()).thenReturn(true);
 
     interfaceIntegrityValidator.execute(stageContext);
 
-    verify(validatorService).validateDescriptors(applicationDescriptors);
+    verify(validatorService).validateDescriptors(applicationDescriptors, TENANT_ID);
   }
 
   @Test
@@ -74,7 +77,7 @@ class InterfaceIntegrityValidatorTest {
     var exception = new RequestValidationException("Invalid interface dependency", "application", APPLICATION_ID);
 
     when(properties.isEnabled()).thenReturn(true);
-    doThrow(exception).when(validatorService).validateDescriptors(applicationDescriptors);
+    doThrow(exception).when(validatorService).validateDescriptors(applicationDescriptors, TENANT_ID);
 
     var stageParameters = Map.of(PARAM_APP_DESCRIPTORS, applicationDescriptors);
     var stageContext = commonStageContext(FLOW_ID, emptyMap(), stageParameters);

--- a/src/test/java/org/folio/entitlement/service/validator/InterfaceIntegrityValidatorTest.java
+++ b/src/test/java/org/folio/entitlement/service/validator/InterfaceIntegrityValidatorTest.java
@@ -47,9 +47,8 @@ class InterfaceIntegrityValidatorTest {
   void execute_positive() {
     var applicationDescriptors = List.of(TestValues.appDescriptor());
     var stageParameters = Map.of(PARAM_APP_DESCRIPTORS, applicationDescriptors);
-    var entitlementReq =  EntitlementRequest.builder().tenantId(TENANT_ID).applications(List.of(APPLICATION_ID));
-    var flowParameters = Map.of(PARAM_REQUEST, entitlementReq);
-    var stageContext = commonStageContext(FLOW_ID, emptyMap(), stageParameters);
+    var flowParameters = Map.of(PARAM_REQUEST, entitlementRequest());
+    var stageContext = commonStageContext(FLOW_ID, flowParameters, stageParameters);
 
     when(properties.isEnabled()).thenReturn(true);
 
@@ -80,7 +79,8 @@ class InterfaceIntegrityValidatorTest {
     doThrow(exception).when(validatorService).validateDescriptors(applicationDescriptors, TENANT_ID);
 
     var stageParameters = Map.of(PARAM_APP_DESCRIPTORS, applicationDescriptors);
-    var stageContext = commonStageContext(FLOW_ID, emptyMap(), stageParameters);
+    var flowParameters = Map.of(PARAM_REQUEST, entitlementRequest());
+    var stageContext = commonStageContext(FLOW_ID, flowParameters, stageParameters);
     assertThatThrownBy(() -> interfaceIntegrityValidator.execute(stageContext))
       .isInstanceOf(RequestValidationException.class)
       .hasMessage("Invalid interface dependency")

--- a/src/test/java/org/folio/entitlement/support/TestValues.java
+++ b/src/test/java/org/folio/entitlement/support/TestValues.java
@@ -36,6 +36,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.folio.common.domain.model.ApplicationDescriptor;
 import org.folio.common.domain.model.Dependency;
+import org.folio.common.domain.model.InterfaceReference;
 import org.folio.common.domain.model.Module;
 import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.entitlement.domain.dto.Entitlement;
@@ -49,6 +50,7 @@ import org.folio.entitlement.domain.entity.key.EntitlementModuleEntity;
 import org.folio.entitlement.domain.model.ApplicationStageContext;
 import org.folio.entitlement.domain.model.CommonStageContext;
 import org.folio.entitlement.domain.model.EntitlementRequest;
+import org.folio.entitlement.domain.model.InterfaceItem;
 import org.folio.entitlement.domain.model.ModuleDescriptorHolder;
 import org.folio.entitlement.domain.model.ModuleStageContext;
 import org.folio.entitlement.domain.model.ModulesSequence;
@@ -186,6 +188,10 @@ public class TestValues {
 
   public static ResultList<ModuleDiscovery> moduleDiscoveries() {
     return asSinglePage(moduleDiscovery());
+  }
+
+  public static InterfaceItem itfItem(String name, String version, String appId) {
+    return new InterfaceItem(new InterfaceReference().id(name).version(version), appId);
   }
 
   public static Dependency applicationDependency(String name, String version) {

--- a/src/test/resources/json/ic/folio-app1-full.json
+++ b/src/test/resources/json/ic/folio-app1-full.json
@@ -1,0 +1,124 @@
+{
+  "id": "folio-app1-1.0.0",
+  "name": "folio-app1",
+  "version": "1.0.0",
+  "modules": [
+    {
+      "id": "folio-module1-1.0.0",
+      "name": "folio-module1",
+      "version": "1.0.0"
+    }
+  ],
+  "uiModules": [
+    {
+      "id": "ui-module1-1.0.0",
+      "name": "ui-module1",
+      "version": "1.0.0"
+    }
+  ],
+  "moduleDescriptors": [
+    {
+      "id": "folio-module1-1.0.0",
+      "name": "Test Folio Module #1",
+      "provides": [
+        {
+          "id": "folio-module1-api",
+          "version": "1.0",
+          "handlers": [
+            {
+              "methods": [ "POST" ],
+              "pathPattern": "/folio-module1/events",
+              "permissionsRequired": [
+                "folio-module1.events.item.post"
+              ]
+            },
+            {
+              "methods": [ "GET" ],
+              "pathPattern": "/folio-module1/events",
+              "permissionsRequired": [ "folio-module1.events.collection.get" ]
+            },
+            {
+              "methods": [ "GET" ],
+              "pathPattern": "/folio-module1/events/{id}",
+              "permissionsRequired": [ "folio-module1.events.item.get" ]
+            }
+          ]
+        },
+        {
+          "id": "_tenant",
+          "version": "2.0",
+          "interfaceType": "system",
+          "handlers": [
+            {
+              "methods": [ "POST" ],
+              "pathPattern": "/_/tenant"
+            },
+            {
+              "methods": [ "GET", "DELETE" ],
+              "pathPattern": "/_/tenant/{id}"
+            }
+          ]
+        },
+        {
+          "id": "_timer",
+          "version": "1.0",
+          "interfaceType": "system",
+          "handlers": [
+            {
+              "methods": [
+                "POST"
+              ],
+              "pathPattern": "/folio-module1/events",
+              "unit": "day",
+              "delay": "5"
+            }
+          ]
+        }
+      ],
+      "permissionSets": [
+        {
+          "permissionName": "folio-module1.events.item.post",
+          "displayName": "Folio Module #1 - Save an event",
+          "description": "Save folio-module1 event"
+        },
+        {
+          "permissionName": "folio-module1.events.collection.get",
+          "displayName": "Folio Module #1 - Get list of events by query",
+          "description": "Get list of folio-module1 events by query"
+        },
+        {
+          "permissionName": "folio-module1.events.item.get",
+          "displayName": "Folio Module #1 - Get event by id",
+          "description": "Get folio-module1 event by id"
+        }
+      ]
+    }
+  ],
+  "uiModuleDescriptors": [
+    {
+      "id": "ui-module1-1.0.0",
+      "name": "Test UI Module #1",
+      "permissionSets": [
+        {
+          "permissionName": "ui-module1.events.collection.view",
+          "displayName": "ui-module1.events.collection.view display name",
+          "description": "ui-module1.events.collection.view description",
+          "subPermissions": [ "ui-module1.events.item.view" ],
+          "visible": true
+        },
+        {
+          "permissionName": "ui-module1.events.item.view",
+          "displayName": "ui-module1.events.item.view display name",
+          "description": "ui-module1.events.item.view description",
+          "subPermissions": [ "folio-module1.events.item.get" ]
+        }
+      ],
+      "requires": [
+        {
+          "id": "folio-module1-api",
+          "version": "1.0"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/ic/folio-app2-full.json
+++ b/src/test/resources/json/ic/folio-app2-full.json
@@ -1,0 +1,85 @@
+{
+  "id": "folio-app2-1.0.0",
+  "name": "folio-app2",
+  "version": "1.0.0",
+  "modules": [
+    {
+      "id": "folio-module2-1.0.0",
+      "name": "folio-module2",
+      "version": "1.0.0"
+    }
+  ],
+  "moduleDescriptors": [
+    {
+      "id": "folio-module2-1.0.0",
+      "name": "Test Folio Module #2",
+      "requires": [
+        {
+          "id": "folio-module1-api",
+          "version": "1.0"
+        }
+      ],
+      "provides": [
+        {
+          "id": "folio-module2-api",
+          "version": "1.0",
+          "handlers": [
+            {
+              "methods": [ "POST" ],
+              "pathPattern": "/folio-module2/events",
+              "permissionsRequired": [ "folio-module2.events.item.post" ]
+            },
+            {
+              "methods": [ "GET" ],
+              "pathPattern": "/folio-module2/events",
+              "permissionsRequired": [ "folio-module2.events.collection.get" ]
+            },
+            {
+              "methods": [ "GET" ],
+              "pathPattern": "/folio-module2/events/{id}",
+              "permissionsRequired": [ "folio-module2.events.item.get" ]
+            }
+          ]
+        },
+        {
+          "id": "_tenant",
+          "version": "2.0",
+          "interfaceType": "system",
+          "handlers": [
+            {
+              "methods": [ "POST" ],
+              "pathPattern": "/_/tenant"
+            },
+            {
+              "methods": [ "GET", "DELETE" ],
+              "pathPattern": "/_/tenant/{id}"
+            }
+          ]
+        }
+      ],
+      "permissionSets": [
+        {
+          "permissionName": "folio-module2.events.item.post",
+          "displayName": "Folio Module #2 - Save an event",
+          "description": "Save an folio-module2 event"
+        },
+        {
+          "permissionName": "folio-module2.events.collection.get",
+          "displayName": "Folio Module #2 - Get list of events by query",
+          "description": "Get list of folio-module2 events by query"
+        },
+        {
+          "permissionName": "folio-module2.events.item.get",
+          "displayName": "Folio Module #2 - Get event by id",
+          "description": "Get an folio-module2 event by id"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "folio-app1",
+      "version": "1.x"
+    }
+  ]
+}

--- a/src/test/resources/json/ic/folio-app3-full.json
+++ b/src/test/resources/json/ic/folio-app3-full.json
@@ -1,0 +1,93 @@
+{
+  "id": "folio-app3-1.0.0",
+  "name": "folio-app3",
+  "version": "1.0.0",
+  "modules": [
+    {
+      "id": "folio-module3-1.0.0",
+      "name": "folio-module3",
+      "version": "1.0.0"
+    }
+  ],
+  "uiModules": [
+    {
+      "id": "ui-module3-1.0.0",
+      "name": "ui-module3",
+      "version": "1.0.0"
+    }
+  ],
+  "moduleDescriptors": [
+    {
+      "id": "folio-module3-1.0.0",
+      "name": "Test Folio Module #3",
+      "requires": [
+        {
+          "id": "folio-module2-api",
+          "version": "1.0"
+        }
+      ],
+      "provides": [
+        {
+          "id": "folio-module3-api",
+          "version": "1.0",
+          "handlers": [
+            {
+              "methods": [ "GET" ],
+              "pathPattern": "/folio-module3/events",
+              "permissionsRequired": [ "folio-module3.events.collection.get" ]
+            }
+          ]
+        },
+        {
+          "id": "_tenant",
+          "version": "2.0",
+          "interfaceType": "system",
+          "handlers": [
+            {
+              "methods": [ "POST" ],
+              "pathPattern": "/_/tenant"
+            },
+            {
+              "methods": [ "GET", "DELETE" ],
+              "pathPattern": "/_/tenant/{id}"
+            }
+          ]
+        }
+      ],
+      "permissionSets": [
+        {
+          "permissionName": "folio-module3.events.item.get",
+          "displayName": "Folio Module #3 - Get event by id",
+          "description": "Get folio-module3 event by id"
+        }
+      ]
+    }
+  ],
+  "uiModuleDescriptors": [
+    {
+      "id": "ui-module3-1.0.0",
+      "name": "Test UI Module #3",
+      "permissionSets": [
+        {
+          "permissionName": "ui-module3.events.item.view",
+          "displayName": "ui-module3.events.item.view display name",
+          "description": "ui-module3.events.item.view description",
+          "subPermissions": [ "folio-module3.events.item.get" ],
+          "visible": true
+        }
+      ],
+      "requires": [
+        {
+          "id": "folio-module3-api",
+          "version": "1.0"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "folio-app2",
+      "version": "1.x"
+    }
+  ]
+}


### PR DESCRIPTION
### **Purpose**
Interface integrity validation should not take into account required interfaces of already entitled applications. 
US: [MGRENTITLE-118](https://folio-org.atlassian.net/browse/MGRENTITLE-118)

### **Approach**
* update both `scoped` and `combined` interface collector to exclude required interfaces of installed application
* the behavior can be controlled via new `VALIDATION_INTERFACE_COLLECTOR_EXCLUDE_ENTITLED_REQUIRED` env variable: if it's `true` -- required interfaces are excluded, `false` -- included (old style)
* replace deprecated `@MockBean` with `@MockitoBean`

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
