### PR TITLE
MGRENTITLE-124: increase maxItems limit for application ids in entitlement requests

### DIFF
--- a/src/main/resources/swagger.api/schemas/entitlementRequestBody.json
+++ b/src/main/resources/swagger.api/schemas/entitlementRequestBody.json
@@ -14,7 +14,7 @@
       "description": "List of application ids",
       "type": "array",
       "minItems": 1,
-      "maxItems": 25,
+      "maxItems": 50,
       "items": {
         "type": "string"
       }

--- a/src/main/resources/swagger.api/schemas/moduleReinstallRequestBody.json
+++ b/src/main/resources/swagger.api/schemas/moduleReinstallRequestBody.json
@@ -18,7 +18,7 @@
       "description": "List of application ids",
       "type": "array",
       "minItems": 1,
-      "maxItems": 25,
+      "maxItems": 50,
       "items": {
         "type": "string"
       }

--- a/src/test/java/org/folio/entitlement/it/NoIntegrationsOkapiEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/NoIntegrationsOkapiEntitlementIT.java
@@ -371,7 +371,7 @@ class NoIntegrationsOkapiEntitlementIT extends BaseIntegrationTest {
         .content(asJsonString(entitlementRequest)))
       .andExpect(status().isBadRequest())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 25")))
+      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 50")))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }
@@ -407,7 +407,7 @@ class NoIntegrationsOkapiEntitlementIT extends BaseIntegrationTest {
         .content(asJsonString(new EntitlementRequestBody().tenantId(TENANT_ID))))
       .andExpect(status().isBadRequest())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 25")))
+      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 50")))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }
@@ -542,7 +542,7 @@ class NoIntegrationsOkapiEntitlementIT extends BaseIntegrationTest {
         .content(asJsonString(entitlementRequest)))
       .andExpect(status().isBadRequest())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 25")))
+      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 50")))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }

--- a/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
@@ -428,7 +428,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
         .content(asJsonString(entitlementRequest)))
       .andExpect(status().isBadRequest())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 25")))
+      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 50")))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }
@@ -462,7 +462,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
         .content(asJsonString(new EntitlementRequestBody().tenantId(TENANT_ID))))
       .andExpect(status().isBadRequest())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 25")))
+      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 50")))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }
@@ -600,7 +600,7 @@ class OkapiEntitlementIT extends BaseIntegrationTest {
         .content(asJsonString(entitlementRequest)))
       .andExpect(status().isBadRequest())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 25")))
+      .andExpect(jsonPath("$.errors[0].message", is("size must be between 1 and 50")))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }


### PR DESCRIPTION
### **Purpose**
The current maximum limit of 25 impacts the entitlement process because the total number of existing applications has risen to 28. Therefore, the limit needs to be increased.

### **Approach**
- Change schema
- update tests

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
