### PR TITLE
MGRENTITLE-134: MTE /reinstall/applications endpoint responding with 403 error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * mgr-tenant-entitlements does not check the cross-application module dependencies as expected (MGRENTITLE-113)
 * Introduce optional application dependencies (MGRAPPS-57)
 * Introduce configuration for FSSP (APPPOCTOOL-59)
+* Reinstall endpoint responding with 403 error (MGRENTITLE-134)
 ---
 
 ## Version `v3.1.0` (09.04.2025)

--- a/src/main/resources/descriptors/ModuleDescriptor.json
+++ b/src/main/resources/descriptors/ModuleDescriptor.json
@@ -253,7 +253,9 @@
         "mgr-tenant-entitlements.flows.all",
         "mgr-tenant-entitlements.entitlements.applications.collection.get",
         "mgr-tenant-entitlements.entitlements.modules.item.get",
-        "mgr-tenant-entitlements.entitlements.validate.post"
+        "mgr-tenant-entitlements.entitlements.validate.post",
+        "mgr-tenant-entitlements.app-reinstallation.execute",
+        "mgr-tenant-entitlements.module-reinstallation.execute"
       ]
     },
     {


### PR DESCRIPTION
### **Purpose**
All reinstall endpoints are responding with a 403 error even with a valid token. [MGRENTITLE-134](https://folio-org.atlassian.net/browse/MGRENTITLE-134)

### **Approach**
- Add permissions to the permission set with property visible: true

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
