### PR TITLE
MGRENTITLE-68 Fix an issue when NoOp validator cannot be extended by Spring

### DIFF
--- a/src/main/java/org/folio/entitlement/service/validator/StageRequestValidator.java
+++ b/src/main/java/org/folio/entitlement/service/validator/StageRequestValidator.java
@@ -14,7 +14,7 @@ public abstract class StageRequestValidator extends DatabaseLoggingStage<CommonS
    * This can be used when a validator is not needed or disabled by configuration,
    * but the flow requires a validator to be present in the pipeline.
    */
-  public static final class NoOp extends StageRequestValidator {
+  public static class NoOp extends StageRequestValidator {
 
     private final String name;
 

--- a/src/test/java/org/folio/entitlement/it/UpgradeValidationInterfaceIntegrityIT.java
+++ b/src/test/java/org/folio/entitlement/it/UpgradeValidationInterfaceIntegrityIT.java
@@ -103,4 +103,27 @@ class UpgradeValidationInterfaceIntegrityIT {
         .andExpect(jsonPath("$.total_records", is(1)));
     }
   }
+
+  @Nested
+  @IntegrationTest
+  @SqlMergeMode(MERGE)
+  @Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
+  @TestPropertySource(properties = {
+    "application.keycloak.enabled=false",
+    "application.okapi.enabled=false",
+    "application.kong.enabled=false",
+    "application.validation.interface-integrity.entitlement.enabled=false",
+    "application.validation.interface-integrity.upgrade.enabled=false"
+  })
+  class ValidationDisabled extends BaseIntegrationTest {
+
+    @Test
+    void validate_positive_incorrectDependencies() throws Exception {
+      var request = entitlementRequest(TENANT_ID, FOLIO_APP2_V2_ID, FOLIO_APP3_ID, FOLIO_APP7_ID);
+
+      attemptPost("/entitlements/validate?entitlementType={type}&validator={validator}",
+        request, UPGRADE.getValue(), VALIDATOR)
+        .andExpect(status().isNoContent());
+    }
+  }
 }


### PR DESCRIPTION
### **Purpose**
NoOp validator class with `final` declaration cannot be properly extended by Spring. That cause application start up to fail if interface integrity validation is disabled:

```
07:55:21 ERROR SpringApplication    Application run failed
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'entitlementController' defined in URL [jar:nested:/usr/verticles/mgr-tenant-entitlements-fat.jar/!BOOT-INF/classes/!/org/folio/entitlement/controller/EntitlementController.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'entitlementService' defined in URL [jar:nested:/usr/verticles/mgr-tenant-entitlements-fat.jar/!BOOT-INF/classes/!/org/folio/entitlement/service/EntitlementService.class]: Unsatisfied dependency expressed through constructor parameter 1: Error creating bean with name 'flowProvider' defined in URL [jar:nested:/usr/verticles/mgr-tenant-entitlements-fat.jar/!BOOT-INF/classes/!/org/folio/entitlement/service/flow/FlowProvider.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'entitleFlowFactory' defined in URL [jar:nested:/usr/verticles/mgr-tenant-entitlements-fat.jar/!BOOT-INF/classes/!/org/folio/entitlement/service/flow/EntitleFlowFactory.class]: Unsatisfied dependency expressed through constructor parameter 3: Error creating bean with name 'entitlementInterfaceIntegrityValidator' defined in class path resource [org/folio/entitlement/service/validator/configuration/InterfaceIntegrityValidationConfiguration$DisabledValidationForEntitlement.class]: Could not generate CGLIB subclass of class org.folio.entitlement.service.validator.StageRequestValidator$NoOp: Common causes of this problem include using a final class or a non-visible class
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:804) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:240) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1395) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:569) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:529) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:339) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:373) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:337) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.instantiateSingleton(DefaultListableBeanFactory.java:1222) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingleton(DefaultListableBeanFactory.java:1188) ~[spring-beans-6.2.9.jar!/:6.2.9]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1123) ~[spring-beans-6.2.9.jar!/:6.2.9]
```
US: [MGRENTITLE-68](https://folio-org.atlassian.net/browse/MGRENTITLE-68)

### **Approach**
* remove `final` declaration from `StageRequestValidator$NoOp` class

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
