### PR TITLE
MGRENTITLE-135 Concurrent Kafka topic creation at application flow level causes intermittent errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Introduce configuration for FSSP (APPPOCTOOL-59)
 * Reinstall endpoint responding with 403 error (MGRENTITLE-134)
 * Validate that upgrade of application does not affect other installed applications (MGRENTITLE-68)
+* Concurrent Kafka topic creation at application flow level causes intermittent errors (MGRENTITLE-135)
 ---
 
 ## Version `v3.1.0` (09.04.2025)

--- a/src/main/java/org/folio/entitlement/service/flow/EntitleApplicationFlowFactory.java
+++ b/src/main/java/org/folio/entitlement/service/flow/EntitleApplicationFlowFactory.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.entitlement.domain.dto.EntitlementType;
-import org.folio.entitlement.integration.kafka.KafkaTenantTopicCreator;
 import org.folio.entitlement.service.stage.ApplicationDependencySaver;
 import org.folio.entitlement.service.stage.ApplicationDescriptorValidator;
 import org.folio.entitlement.service.stage.ApplicationDiscoveryLoader;
@@ -28,7 +27,6 @@ public class EntitleApplicationFlowFactory implements ApplicationFlowFactory {
   private final ApplicationDependencySaver applicationDependencySaver;
   private final ApplicationDiscoveryLoader applicationDiscoveryLoader;
   private final EntitleRequestDependencyValidator entitleRequestDependencyValidator;
-  private final KafkaTenantTopicCreator kafkaTenantTopicCreator;
 
   private final ModulesFlowProvider modulesFlowFactory;
   private final ApplicationFlowInitializer flowInitializer;
@@ -54,7 +52,6 @@ public class EntitleApplicationFlowFactory implements ApplicationFlowFactory {
       .stage(applicationDependencySaver)
       .stage(entitleRequestDependencyValidator)
       .stage(applicationDiscoveryLoader)
-      .stage(kafkaTenantTopicCreator)
       .stage(DynamicStage.of(modulesFlowFactory.getName(), modulesFlowFactory::createFlow))
       .stage(finishedFlowFinalizer)
       .onFlowSkip(skippedFlowFinalizer)

--- a/src/main/java/org/folio/entitlement/service/flow/EntitleFlowFactory.java
+++ b/src/main/java/org/folio/entitlement/service/flow/EntitleFlowFactory.java
@@ -5,6 +5,7 @@ import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_REQUES
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.entitlement.domain.model.EntitlementRequest;
+import org.folio.entitlement.integration.kafka.KafkaTenantTopicCreator;
 import org.folio.entitlement.service.stage.ApplicationDescriptorTreeLoader;
 import org.folio.entitlement.service.stage.CancellationFailedFlowFinalizer;
 import org.folio.entitlement.service.stage.CancelledFlowFinalizer;
@@ -30,6 +31,7 @@ public class EntitleFlowFactory implements FlowFactory {
   private final StageRequestValidator interfaceIntegrityValidator;
   private final ApplicationFlowQueuingStage applicationFlowQueuingStage;
   private final ApplicationDescriptorTreeLoader applicationDescriptorTreeLoader;
+  private final KafkaTenantTopicCreator kafkaTenantTopicCreator;
 
   private final FinishedFlowFinalizer finishedFlowFinalizer;
   private final FlowInitializer flowInitializer;
@@ -47,6 +49,7 @@ public class EntitleFlowFactory implements FlowFactory {
       .stage(applicationDescriptorTreeLoader)
       .stage(interfaceIntegrityValidator)
       .stage(applicationFlowQueuingStage)
+      .stage(kafkaTenantTopicCreator)
       .stage(DynamicStage.of(applicationsFlowFactory.getName(), applicationsFlowFactory::createFlow))
       .stage(finishedFlowFinalizer)
       .onFlowError(failedFlowFinalizer)

--- a/src/test/java/org/folio/entitlement/it/UpgradeValidationInterfaceIntegrityIT.java
+++ b/src/test/java/org/folio/entitlement/it/UpgradeValidationInterfaceIntegrityIT.java
@@ -18,7 +18,6 @@ import org.folio.entitlement.service.validator.InterfaceIntegrityValidator;
 import org.folio.entitlement.support.base.BaseIntegrationTest;
 import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
@@ -44,7 +43,6 @@ class UpgradeValidationInterfaceIntegrityIT {
     "application.okapi.enabled=false",
     "application.kong.enabled=false",
   })
-  @Disabled("Disabled until the issue with concurrent kafka topic creation is resolved")
   class ValidationEnabled extends BaseIntegrationTest {
 
     @Test

--- a/src/test/java/org/folio/entitlement/service/flow/EntitleApplicationFlowFactoryTest.java
+++ b/src/test/java/org/folio/entitlement/service/flow/EntitleApplicationFlowFactoryTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 import org.folio.entitlement.domain.model.ApplicationStageContext;
 import org.folio.entitlement.domain.model.EntitlementRequest;
 import org.folio.entitlement.domain.model.IdentifiableStageContext;
-import org.folio.entitlement.integration.kafka.KafkaTenantTopicCreator;
 import org.folio.entitlement.service.stage.ApplicationDependencySaver;
 import org.folio.entitlement.service.stage.ApplicationDescriptorValidator;
 import org.folio.entitlement.service.stage.ApplicationDiscoveryLoader;
@@ -52,7 +51,6 @@ class EntitleApplicationFlowFactoryTest {
   @Mock private ApplicationDependencySaver applicationDependencySaver;
   @Mock private ApplicationDiscoveryLoader applicationDiscoveryLoader;
   @Mock private EntitleRequestDependencyValidator entitleRequestDependencyValidator;
-  @Mock private KafkaTenantTopicCreator kafkaTenantTopicCreator;
 
   @Mock private ModulesFlowProvider modulesFlowProvider;
   @Mock private ApplicationFlowInitializer flowInitializer;
@@ -70,7 +68,7 @@ class EntitleApplicationFlowFactoryTest {
   @Test
   void prepareFlow_positive() {
     mockStageNames(applicationDescriptorValidator, applicationDependencySaver,
-      entitleRequestDependencyValidator, applicationDiscoveryLoader, kafkaTenantTopicCreator,
+      entitleRequestDependencyValidator, applicationDiscoveryLoader,
       finishedFlowFinalizer, flowInitializer, failedFlowFinalizer, cancelledFlowFinalizer,
       cancellationFailedApplicationFlowFinalizer, skippedFlowFinalizer);
 
@@ -83,8 +81,7 @@ class EntitleApplicationFlowFactoryTest {
     var context = appStageContext(actual.getId(), flowParameters, emptyMap());
 
     var inOrder = Mockito.inOrder(flowInitializer, applicationDependencySaver, entitleRequestDependencyValidator,
-      applicationDiscoveryLoader, finishedFlowFinalizer, applicationDescriptorValidator,
-      kafkaTenantTopicCreator, modulesFlowProvider);
+      applicationDiscoveryLoader, finishedFlowFinalizer, applicationDescriptorValidator, modulesFlowProvider);
 
     inOrder.verify(modulesFlowProvider).getName();
     verifyStageExecution(inOrder, flowInitializer, context);
@@ -92,7 +89,6 @@ class EntitleApplicationFlowFactoryTest {
     verifyStageExecution(inOrder, applicationDependencySaver, context);
     verifyStageExecution(inOrder, entitleRequestDependencyValidator, context);
     verifyStageExecution(inOrder, applicationDiscoveryLoader, context);
-    verifyStageExecution(inOrder, kafkaTenantTopicCreator, context);
     inOrder.verify(modulesFlowProvider).createFlow(context);
     verifyStageExecution(inOrder, finishedFlowFinalizer, context);
 


### PR DESCRIPTION
### **Purpose**
Tenant specific topics are created during application flow execution. Time to time the creation fails when several applications are being installed in parallel. To address the issue topic creation should be moved at the entitlement flow level.
US: [MGRENTITLE-135](https://folio-org.atlassian.net/browse/MGRENTITLE-135)

### **Approach**
* move tenant Kafka topic creation from `EntitleApplicationFlowFactory` to `EntitleFlowFactory`
* when creating the topics check what exists and what not by using `KafkaAdminService.findTopics()` method. Create only topics that are not present already.
* enable interface integrity validation tests disabled due to the issue
---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [x] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
