### PR TITLE
MGRENTITLE-139 - SECURE_STORE_ENV use ENV value if exist

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,7 +131,7 @@ application:
         trust-store-password: ${FOLIO_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
         trust-store-type: ${FOLIO_CLIENT_TLS_TRUSTSTORE_TYPE:}
   secret-store:
-    environment: ${SECURE_STORE_ENV:folio}
+    environment: ${SECURE_STORE_ENV:${ENV:folio}}
     type: ${SECRET_STORE_TYPE:}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}


### PR DESCRIPTION
### **Purpose**
[MGRENTITLE-139](https://folio-org.atlassian.net/browse/MGRENTITLE-139) - Use SECURE_STORE_ENV, not ENV, for secure store key

### **Approach**
Provide a brief technical summary of the changes.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
