### PR TITLE
MGRENTITLE-139 - revert Use SECURE_STORE_ENV, not ENV, for secure store key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,6 @@
 * Reinstall endpoint responding with 403 error (MGRENTITLE-134)
 * Validate that upgrade of application does not affect other installed applications (MGRENTITLE-68)
 * Concurrent Kafka topic creation at application flow level causes intermittent errors (MGRENTITLE-135)
-* Use SECURE_STORE_ENV, not ENV, for secure store key (MGRENTITLE-139)
-
 ---
 
 ## Version `v3.1.0` (09.04.2025)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mgr-tenant-entitlements
 
-Copyright (C) 2022-2025 The Open Library Foundation
+Copyright (C) 2022-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
@@ -133,7 +133,6 @@ docker run \
 | FOLIO_CLIENT_TLS_TRUSTSTORE_PASSWORD   | -                                   |  false   | Truststore password for TLS connection to Folio Modules.                                                                                                                                                   |
 | FOLIO_CLIENT_TLS_TRUSTSTORE_TYPE       | -                                   |  false   | Truststore file type for TLS connection to Folio Modules.                                                                                                                                                  |
 | MOD_AUTHTOKEN_URL                      | -                                   |   true   | Mod-authtoken URL. Required if OKAPI_INTEGRATION_ENABLED is true and SECURITY_ENABLED  is true and KC_INTEGRATION_ENABLED is false.                                                                        |
-| SECURE\_STORE\_ENV                     | folio                               |  false   | First segment of the secure store key, for example `prod` or `test`. Defaults to `folio`. In Ramsons and Sunflower defaults to ENV with fall-back `folio`.                                                 |
 | SECRET_STORE_TYPE                      | -                                   |   true   | Secure storage type. Supported values: `EPHEMERAL`, `AWS_SSM`, `VAULT`, `FSSP`                                                                                                                             |
 | MAX_HTTP_REQUEST_HEADER_SIZE           | 200KB                               |  false   | Maximum size of the HTTP request header.                                                                                                                                                                   |
 | FLOW_ENGINE_EXECUTION_TIMEOUT          | 30m                                 |  false   | Maximum execution timeout for entitlement execution in sync mode.                                                                                                                                          |

--- a/src/main/java/org/folio/entitlement/integration/keycloak/configuration/KeycloakConfiguration.java
+++ b/src/main/java/org/folio/entitlement/integration/keycloak/configuration/KeycloakConfiguration.java
@@ -15,7 +15,7 @@ import org.folio.entitlement.integration.keycloak.configuration.properties.Keycl
 import org.folio.entitlement.retry.keycloak.KeycloakRetrySupportService;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.folio.security.integration.keycloak.service.KeycloakModuleDescriptorMapper;
-import org.folio.security.integration.keycloak.service.KeycloakStoreKeyProvider;
+import org.folio.security.integration.keycloak.utils.KeycloakSecretUtils;
 import org.folio.tools.store.SecureStore;
 import org.folio.tools.store.exception.SecretNotFoundException;
 import org.keycloak.admin.client.Keycloak;
@@ -29,11 +29,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties(KeycloakProperties.class)
-@ConditionalOnBean({ KeycloakConfigurationProperties.class, KeycloakStoreKeyProvider.class })
+@ConditionalOnBean(KeycloakConfigurationProperties.class)
 public class KeycloakConfiguration {
 
   private final KeycloakProperties properties;
-  private final KeycloakStoreKeyProvider keycloakStoreKeyProvider;
   private final SecureStore secureStore;
 
   @Bean
@@ -94,7 +93,7 @@ public class KeycloakConfiguration {
 
   private String getKeycloakClientSecret(String clientId) {
     try {
-      return secureStore.get(keycloakStoreKeyProvider.globalStoreKey(clientId));
+      return secureStore.get(KeycloakSecretUtils.globalStoreKey(clientId));
     } catch (SecretNotFoundException e) {
       log.debug("Secret for 'admin' client is not defined in the secret store: clientId = {}", clientId);
       return null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,7 +131,7 @@ application:
         trust-store-password: ${FOLIO_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
         trust-store-type: ${FOLIO_CLIENT_TLS_TRUSTSTORE_TYPE:}
   secret-store:
-    environment: ${SECURE_STORE_ENV:${ENV:folio}}
+    environment: ${SECURE_STORE_ENV:folio}
     type: ${SECRET_STORE_TYPE:}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,7 +131,6 @@ application:
         trust-store-password: ${FOLIO_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
         trust-store-type: ${FOLIO_CLIENT_TLS_TRUSTSTORE_TYPE:}
   secret-store:
-    environment: ${SECURE_STORE_ENV:folio}
     type: ${SECRET_STORE_TYPE:}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}

--- a/src/test/java/org/folio/entitlement/it/AbstractFolioEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/AbstractFolioEntitlementIT.java
@@ -56,7 +56,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
-import org.awaitility.Awaitility;
 import org.folio.common.utils.OkapiHeaders;
 import org.folio.entitlement.integration.kafka.model.EntitlementEvent;
 import org.folio.entitlement.integration.kafka.model.ResourceEvent;
@@ -318,29 +317,26 @@ abstract class AbstractFolioEntitlementIT extends BaseIntegrationTest {
     "/wiremock/folio-module2/install-timeout.json"
   })
   void install_negative_readTimeoutOnModuleCancellation() throws Exception {
-    Awaitility.await().untilAsserted(() -> {
-      mockMvc.perform(post(updatePathWithPrefix("/entitlements"))
-          .queryParam("tenantParameters", "loadReference=true")
-          .queryParam("ignoreErrors", "false")
-          .queryParam("purgeOnRollback", "true")
-          .contentType(APPLICATION_JSON)
-          .header(TOKEN, getSystemAccessToken())
-          .content(asJsonString(entitlementRequest(FOLIO_APP5_ID))))
-        .andExpect(status().isBadRequest())
-        .andExpect(content().contentType(APPLICATION_JSON))
-        .andExpect(jsonPath("$.total_records", is(1)))
-        .andExpect(jsonPath("$.errors[0].type", is("FlowCancellationException")))
-        .andExpect(jsonPath("$.errors[0].message",
-            matchesPattern("Flow '.+' finished with status: CANCELLATION_FAILED")))
-        .andExpect(jsonPath("$.errors[0].parameters[0].key", is("folio-module2-2.0.0-folioModuleInstaller")))
-        .andExpect(jsonPath("$.errors[0].parameters[0].value", matchesPattern(
-          "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-            + "\\[method: POST, uri: http://.+:\\d+/folio-module2/_/tenant], cause: request timed out")))
-        .andExpect(jsonPath("$.errors[0].parameters[1].key", is("folio-module1-1.0.0-folioModuleInstaller")))
-        .andExpect(jsonPath("$.errors[0].parameters[1].value", matchesPattern(
-          "CANCELLATION_FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
-            + "\\[method: POST, uri: http://.+:\\d+/folio-module1/_/tenant], cause: request timed out")));
-    });
+    mockMvc.perform(post(updatePathWithPrefix("/entitlements"))
+        .queryParam("tenantParameters", "loadReference=true")
+        .queryParam("ignoreErrors", "false")
+        .queryParam("purgeOnRollback", "true")
+        .contentType(APPLICATION_JSON)
+        .header(TOKEN, getSystemAccessToken())
+        .content(asJsonString(entitlementRequest(FOLIO_APP5_ID))))
+      .andExpect(status().isBadRequest())
+      .andExpect(content().contentType(APPLICATION_JSON))
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].type", is("FlowCancellationException")))
+      .andExpect(jsonPath("$.errors[0].message", matchesPattern("Flow '.+' finished with status: CANCELLATION_FAILED")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("folio-module2-2.0.0-folioModuleInstaller")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].value", matchesPattern(
+        "FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
+          + "\\[method: POST, uri: http://.+:\\d+/folio-module2/_/tenant], cause: request timed out")))
+      .andExpect(jsonPath("$.errors[0].parameters[1].key", is("folio-module1-1.0.0-folioModuleInstaller")))
+      .andExpect(jsonPath("$.errors[0].parameters[1].value", matchesPattern(
+        "CANCELLATION_FAILED: \\[IntegrationException] \\[HttpTimeoutException] Failed to perform request "
+          + "\\[method: POST, uri: http://.+:\\d+/folio-module1/_/tenant], cause: request timed out")));
 
     getEntitlementsByQuery(queryByTenantAndAppId(FOLIO_APP5_ID), emptyEntitlements());
 

--- a/src/test/java/org/folio/entitlement/it/EntitlementFlowIT.java
+++ b/src/test/java/org/folio/entitlement/it/EntitlementFlowIT.java
@@ -5,7 +5,6 @@ import static org.folio.entitlement.domain.dto.EntitlementType.ENTITLE;
 import static org.folio.entitlement.domain.dto.ExecutionStatus.FAILED;
 import static org.folio.entitlement.domain.dto.ExecutionStatus.FINISHED;
 import static org.folio.entitlement.support.TestUtils.parseResponse;
-import static org.folio.entitlement.utils.IntegrationTestUtil.getDefaultKeycloakStoreKeyProvider;
 import static org.folio.test.TestConstants.OKAPI_AUTH_TOKEN;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
@@ -26,7 +25,6 @@ import org.folio.entitlement.domain.dto.Flow;
 import org.folio.entitlement.domain.dto.FlowStage;
 import org.folio.entitlement.domain.dto.FlowStages;
 import org.folio.entitlement.support.base.BaseIntegrationTest;
-import org.folio.security.integration.keycloak.service.KeycloakStoreKeyProvider;
 import org.folio.test.extensions.EnableKeycloakSecurity;
 import org.folio.test.extensions.EnableKeycloakTlsMode;
 import org.folio.test.types.IntegrationTest;
@@ -35,15 +33,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.keycloak.admin.client.Keycloak;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.jdbc.Sql;
 
 @EnableKeycloakTlsMode
 @IntegrationTest
 @EnableKeycloakSecurity
-@Import(EntitlementFlowIT.TestConfiguration.class)
 @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = "classpath:/sql/entitlement-flow-data.sql")
 @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "classpath:/sql/truncate-tables.sql")
 class EntitlementFlowIT extends BaseIntegrationTest {
@@ -283,14 +277,5 @@ class EntitlementFlowIT extends BaseIntegrationTest {
       .status(FINISHED)
       .startedAt(timestampFrom(startedAt))
       .finishedAt(timestampFrom(finishedAt));
-  }
-
-  static class TestConfiguration {
-
-    @Bean
-    @Primary
-    public KeycloakStoreKeyProvider keycloakStoreKeyProvider() {
-      return getDefaultKeycloakStoreKeyProvider();
-    }
   }
 }

--- a/src/test/java/org/folio/entitlement/it/KeycloakRetriesIT.java
+++ b/src/test/java/org/folio/entitlement/it/KeycloakRetriesIT.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.entitlement.support.TestUtils.asJsonString;
 import static org.folio.entitlement.support.TestValues.entitlementRequest;
 import static org.folio.entitlement.utils.IntegrationTestUtil.extractFlowIdFromFailedEntitlementResponse;
-import static org.folio.entitlement.utils.IntegrationTestUtil.getDefaultKeycloakStoreKeyProvider;
 import static org.folio.entitlement.utils.IntegrationTestUtil.getFlowStage;
 import static org.folio.entitlement.utils.LogTestUtil.captureLog4J2Logs;
 import static org.folio.entitlement.utils.LogTestUtil.stopCaptureLog4J2Logs;
@@ -26,7 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.util.List;
 import java.util.Map;
-import org.awaitility.Awaitility;
 import org.folio.entitlement.integration.keycloak.KeycloakService;
 import org.folio.entitlement.integration.keycloak.configuration.properties.KeycloakConfigurationProperties;
 import org.folio.entitlement.integration.keycloak.configuration.properties.KeycloakConfigurationProperties.Login;
@@ -35,7 +33,6 @@ import org.folio.entitlement.support.base.BaseIntegrationTest;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakAdminProperties;
 import org.folio.security.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.folio.security.integration.keycloak.service.KeycloakModuleDescriptorMapper;
-import org.folio.security.integration.keycloak.service.KeycloakStoreKeyProvider;
 import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.folio.tools.kong.client.KongAdminClient.KongResultList;
@@ -115,17 +112,13 @@ class KeycloakRetriesIT extends BaseIntegrationTest {
       e -> e.getRequest().getUrl().equals("/admin/realms/test/clients/test/authz/resource-server/resource")
         && e.getRequest().getBodyAsString().contains("POST#folio-module1.events.item.post")).count()).isEqualTo(3);
 
-    Awaitility.await().untilAsserted(() -> {  // ignore ConcurrentModificationException
-      assertThat(
-          logs.stream().filter(logLine -> logLine.contains("Error occurred for Keycloak access - retrying")))
-        .hasSize(7);
-      assertThat(logs.stream().filter(
-          logLine -> logLine.contains("jakarta.ws.rs.WebApplicationException: HTTP 500 Internal Server Error")))
-        .hasSize(6);
-      assertThat(logs.stream().filter(logLine -> logLine.contains("Flow stage KeycloakModuleResourceCreator "
-          + "folio-module1-1.0.0-keycloakModuleResourceCreator execution error")))
-        .hasSize(1);
-    });
+    assertThat(
+      logs.stream().filter(logLine -> logLine.contains("Error occurred for Keycloak access - retrying"))).hasSize(7);
+    assertThat(logs.stream().filter(
+      logLine -> logLine.contains("jakarta.ws.rs.WebApplicationException: HTTP 500 Internal Server Error"))).hasSize(6);
+    assertThat(logs.stream().filter(logLine -> logLine.contains(
+      "Flow stage KeycloakModuleResourceCreator folio-module1-1.0.0-keycloakModuleResourceCreator execution error")))
+      .hasSize(1);
 
     var flowStageData = getFlowStage(extractFlowIdFromFailedEntitlementResponse(response.getResponse()),
       "folio-module1-1.0.0-keycloakModuleResourceCreator", mockMvc);
@@ -168,15 +161,13 @@ class KeycloakRetriesIT extends BaseIntegrationTest {
         "/admin/realms/test/clients/test/authz/resource-server/resource?name=%2Ffolio-module2%2Fevents%2F%7Bid%7D"))
       .count()).isEqualTo(3);
 
-    Awaitility.await().untilAsserted(() -> {  // ignore ConcurrentModificationException
-      assertThat(
-        logs.stream().filter(logLine -> logLine.contains("Error occurred for Keycloak access - retrying"))).hasSize(7);
-      assertThat(logs.stream().filter(logLine -> logLine.contains(
-        "jakarta.ws.rs.InternalServerErrorException: HTTP 500 Internal Server Error"))).hasSize(6);
-      assertThat(logs.stream().filter(logLine -> logLine.contains(
-        "Flow stage KeycloakModuleResourceCleaner folio-module2-2.0.0-keycloakModuleResourceCleaner execution error")))
-        .hasSize(1);
-    });
+    assertThat(
+      logs.stream().filter(logLine -> logLine.contains("Error occurred for Keycloak access - retrying"))).hasSize(7);
+    assertThat(logs.stream().filter(logLine -> logLine.contains(
+      "jakarta.ws.rs.InternalServerErrorException: HTTP 500 Internal Server Error"))).hasSize(6);
+    assertThat(logs.stream().filter(logLine -> logLine.contains(
+      "Flow stage KeycloakModuleResourceCleaner folio-module2-2.0.0-keycloakModuleResourceCleaner execution error")))
+      .hasSize(1);
 
     var flowStageData = getFlowStage(extractFlowIdFromFailedEntitlementResponse(response.getResponse()),
       "folio-module2-2.0.0-keycloakModuleResourceCleaner", mockMvc);
@@ -235,12 +226,6 @@ class KeycloakRetriesIT extends BaseIntegrationTest {
       adminProps.setUsername("admin");
       adminProps.setPassword("secret");
       return result;
-    }
-
-    @Bean
-    @Primary
-    public KeycloakStoreKeyProvider keycloakStoreKeyProvider() {
-      return getDefaultKeycloakStoreKeyProvider();
     }
 
     @Bean

--- a/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/OkapiEntitlementIT.java
@@ -88,9 +88,7 @@ import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.extensions.WireMockStub;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -111,7 +109,6 @@ import org.springframework.test.context.jdbc.SqlMergeMode;
 })
 @Import(KeycloakTestClientConfiguration.class)
 @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "/sql/truncate-tables.sql")
-@TestMethodOrder(MethodOrderer.MethodName.class)
 class OkapiEntitlementIT extends BaseIntegrationTest {
 
   private static final String OKAPI_APP_ID = "okapi-app-1.0.0";

--- a/src/test/java/org/folio/entitlement/support/KeycloakTestClientConfiguration.java
+++ b/src/test/java/org/folio/entitlement/support/KeycloakTestClientConfiguration.java
@@ -10,7 +10,6 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.entitlement.support.TestConstants.HTTP_CLIENT_DUMMY_SSL;
 import static org.folio.entitlement.support.TestUtils.OBJECT_MAPPER;
-import static org.folio.entitlement.utils.IntegrationTestUtil.getDefaultKeycloakStoreKeyProvider;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpMethod.DELETE;
@@ -46,23 +45,15 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.entitlement.integration.keycloak.configuration.properties.KeycloakConfigurationProperties;
 import org.folio.entitlement.support.model.AuthorizationResource;
-import org.folio.security.integration.keycloak.service.KeycloakStoreKeyProvider;
 import org.keycloak.admin.client.Keycloak;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpMethod;
 
 @Log4j2
 @TestConfiguration
 @RequiredArgsConstructor
 public class KeycloakTestClientConfiguration {
-
-  @Bean
-  @Primary
-  public KeycloakStoreKeyProvider keycloakStoreKeyProvider() {
-    return getDefaultKeycloakStoreKeyProvider();
-  }
 
   @Bean
   public KeycloakTestClient keycloakTestClient(

--- a/src/test/java/org/folio/entitlement/utils/IntegrationTestUtil.java
+++ b/src/test/java/org/folio/entitlement/utils/IntegrationTestUtil.java
@@ -9,8 +9,6 @@ import java.io.UnsupportedEncodingException;
 import lombok.experimental.UtilityClass;
 import org.folio.entitlement.domain.dto.Flow;
 import org.folio.entitlement.domain.dto.FlowStage;
-import org.folio.security.integration.keycloak.service.KeycloakStoreKeyProvider;
-import org.folio.tools.store.properties.SecureStoreProperties;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -33,11 +31,5 @@ public class IntegrationTestUtil {
         .getContentAsByteArray(), Flow.class);
     return flowData.getApplicationFlows().get(0).getStages().stream().filter(s -> s.getName().equals(stageName))
       .findAny().orElseThrow();
-  }
-
-  public static KeycloakStoreKeyProvider getDefaultKeycloakStoreKeyProvider() {
-    var secureStoreProperties = new SecureStoreProperties();
-    secureStoreProperties.setEnvironment("folio");
-    return new KeycloakStoreKeyProvider(secureStoreProperties);
   }
 }


### PR DESCRIPTION
### **Purpose**
 Revert Use SECURE_STORE_ENV, not ENV, for secure store key

### **Approach**
Revert Use SECURE_STORE_ENV, not ENV, for secure store key

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
