### PR TITLE
NOJIRA: add warn logging for Keycloak authorization failures

### DIFF
--- a/src/main/java/org/folio/entitlement/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/entitlement/integration/keycloak/KeycloakService.java
@@ -161,12 +161,15 @@ public class KeycloakService {
     try (var response = retrySupport.callWithRetry(() -> failOnInternalServerError(client.scopes().create(scope)))) {
       var status = response.getStatus();
       if (status >= SC_BAD_REQUEST && status != SC_CONFLICT) {
+        log.warn("Failed to create Keycloak scope: name = {}, status = {}, info = {}",
+          scopeName, status, response.getStatusInfo());
         return Optional.of(getScopeError(format(
           "Failed to create scope %s (status: %s, info: %s)", scope.getName(), status, response.getStatusInfo())));
       }
 
       log.debug("Scope was created with name: #{}", scopeName);
     } catch (Exception exception) {
+      log.warn("Failed to create Keycloak scope: name = {}", scopeName, exception);
       return Optional.of(getScopeError(format("Failed to create scope %s (cause: %s, causeMessage: %s)",
         scopeName, exception.getClass().getSimpleName(), exception.getMessage())));
     }
@@ -201,12 +204,15 @@ public class KeycloakService {
 
       if (status >= SC_BAD_REQUEST) {
         var statusInfo = response.getStatusInfo();
+        log.warn("Failed to create Keycloak resource: name = {}, status = {}, info = {}",
+          name, status, statusInfo);
         var errorMessage = format("Failed to create resource: %s (status: %s, info: %s)", name, status, statusInfo);
         return Optional.of(getResourceError(errorMessage));
       }
 
       log.debug("Resource was created with name: #{}", name);
     } catch (Exception exception) {
+      log.warn("Failed to create Keycloak resource: name = {}", name, exception);
       return Optional.of(getResourceError(format("Failed to create resource: %s (cause: %s, causeMessage: %s)",
         name, exception.getClass().getSimpleName(), exception.getMessage())));
     }
@@ -218,6 +224,7 @@ public class KeycloakService {
     var name = resource.getName();
     var resourceByName = findResourceByName(client, name);
     if (resourceByName.isEmpty()) {
+      log.warn("Failed to update Keycloak resource: name = {}, created resource lookup returned empty result", name);
       return Optional.of(getResourceError("Failed to find created resource by name: " + name));
     }
 
@@ -230,6 +237,8 @@ public class KeycloakService {
       log.debug("Authorization scopes are updated for resource: name = {}", name);
       return Optional.empty();
     } catch (WebApplicationException exception) {
+      log.warn("Failed to update Keycloak resource: name = {}, status = {}",
+        name, exception.getResponse().getStatus(), exception);
       var param = getResourceError(format("Failed to update resource: %s (status: %s, causeMessage: %s)",
         name, exception.getResponse().getStatus(), exception.getMessage()));
       return Optional.of(param);
@@ -262,6 +271,8 @@ public class KeycloakService {
     } catch (WebApplicationException exception) {
       var response = exception.getResponse();
       if (response.getStatus() != SC_NOT_FOUND) {
+        log.warn("Failed to delete Keycloak resource: name = {}, status = {}, info = {}",
+          resourceName, response.getStatus(), response.getStatusInfo(), exception);
         var value = format("Failed to delete resource: %s (status: %s, causeMessage: %s)",
           resourceName, response.getStatusInfo(), exception.getMessage());
         return Optional.of(getResourceError(value));

--- a/src/main/java/org/folio/entitlement/integration/keycloak/KeycloakService.java
+++ b/src/main/java/org/folio/entitlement/integration/keycloak/KeycloakService.java
@@ -169,7 +169,8 @@ public class KeycloakService {
 
       log.debug("Scope was created with name: #{}", scopeName);
     } catch (Exception exception) {
-      log.warn("Failed to create Keycloak scope: name = {}", scopeName, exception);
+      log.warn("Failed to create Keycloak scope: name = {}, cause = {}, causeMessage = {}",
+        scopeName, exception.getClass().getSimpleName(), exception.getMessage());
       return Optional.of(getScopeError(format("Failed to create scope %s (cause: %s, causeMessage: %s)",
         scopeName, exception.getClass().getSimpleName(), exception.getMessage())));
     }
@@ -204,15 +205,15 @@ public class KeycloakService {
 
       if (status >= SC_BAD_REQUEST) {
         var statusInfo = response.getStatusInfo();
-        log.warn("Failed to create Keycloak resource: name = {}, status = {}, info = {}",
-          name, status, statusInfo);
+        log.warn("Failed to create Keycloak resource: name = {}, status = {}, info = {}", name, status, statusInfo);
         var errorMessage = format("Failed to create resource: %s (status: %s, info: %s)", name, status, statusInfo);
         return Optional.of(getResourceError(errorMessage));
       }
 
       log.debug("Resource was created with name: #{}", name);
     } catch (Exception exception) {
-      log.warn("Failed to create Keycloak resource: name = {}", name, exception);
+      log.warn("Failed to create Keycloak resource: name = {}, cause = {}, causeMessage = {}",
+        name, exception.getClass().getSimpleName(), exception.getMessage());
       return Optional.of(getResourceError(format("Failed to create resource: %s (cause: %s, causeMessage: %s)",
         name, exception.getClass().getSimpleName(), exception.getMessage())));
     }
@@ -237,8 +238,8 @@ public class KeycloakService {
       log.debug("Authorization scopes are updated for resource: name = {}", name);
       return Optional.empty();
     } catch (WebApplicationException exception) {
-      log.warn("Failed to update Keycloak resource: name = {}, status = {}",
-        name, exception.getResponse().getStatus(), exception);
+      log.warn("Failed to update Keycloak resource: name = {}, status = {}, causeMessage = {}",
+        name, exception.getResponse().getStatus(), exception.getMessage());
       var param = getResourceError(format("Failed to update resource: %s (status: %s, causeMessage: %s)",
         name, exception.getResponse().getStatus(), exception.getMessage()));
       return Optional.of(param);
@@ -271,8 +272,8 @@ public class KeycloakService {
     } catch (WebApplicationException exception) {
       var response = exception.getResponse();
       if (response.getStatus() != SC_NOT_FOUND) {
-        log.warn("Failed to delete Keycloak resource: name = {}, status = {}, info = {}",
-          resourceName, response.getStatus(), response.getStatusInfo(), exception);
+        log.warn("Failed to delete Keycloak resource: name = {}, status = {}, info = {}, causeMessage = {}",
+          resourceName, response.getStatus(), response.getStatusInfo(), exception.getMessage());
         var value = format("Failed to delete resource: %s (status: %s, causeMessage: %s)",
           resourceName, response.getStatusInfo(), exception.getMessage());
         return Optional.of(getResourceError(value));


### PR DESCRIPTION
### **Purpose**
NOJIRA.
Adds warn-level logging for Keycloak authorization scope and resource failures that were previously only returned as error parameters.
This makes failed Keycloak authorization updates easier to diagnose without changing the existing error handling flow.

### **Approach**
- Added warn logs for failed scope creation responses and exceptions.
- Added warn logs for failed resource creation, update, and delete paths.
- Kept existing response handling, retry behavior, and returned error parameters unchanged.

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.