### PR TITLE
MGRENTITLE-180: Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenant-entitlements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## Version `v4.1.0` (In Progress)
+* Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenant-entitlements (MGRENTITLE-180)
+
+---
+
 ## Version `4.0.0` (16.04.2026)
 * Not able to entitle application due to dependency issue (MGRENTITLE-118)
 * mgr-tenant-entitlements does not check the cross-application module dependencies as expected (MGRENTITLE-113)

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,9 @@
     <mgr-tenant-entitlements.yaml-file>${project.basedir}/src/main/resources/swagger.api/mgr-tenant-entitlements.yaml
     </mgr-tenant-entitlements.yaml-file>
 
+    <!-- overrides Spring Boot BOM default; can be removed once Spring Boot ships this version -->
+    <kafka.version>4.2.0</kafka.version>
+
     <!-- Test dependencies versions -->
     <mockito.version>5.23.0</mockito.version>
     <testcontainer.version>2.0.5</testcontainer.version>


### PR DESCRIPTION
### **Purpose**
Fix for [MGRENTITLE-180](https://folio-org.atlassian.net/browse/MGRENTITLE-180)

### **Approach**
Added following to pom file - `<kafka.version>4.2.0</kafka.version>`
After the change, maven effective pom shows correct kafka version
<img width="1078" height="648" alt="image" src="https://github.com/user-attachments/assets/dc24d7e8-a654-453a-a7a1-dbdc5a987c4b" />

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
