### PR TITLE
EUREKASUP-156: Multi-version module deployment – propagate applicationId in entitlement events

### DIFF
--- a/src/main/java/org/folio/entitlement/integration/folio/stage/FolioModuleEventPublisher.java
+++ b/src/main/java/org/folio/entitlement/integration/folio/stage/FolioModuleEventPublisher.java
@@ -53,6 +53,6 @@ public class FolioModuleEventPublisher extends ModuleDatabaseLoggingStage {
   }
 
   private static EntitlementEvent getEntitlementEvent(String moduleId, ModuleStageContext ctx, EntitlementType type) {
-    return new EntitlementEvent(type.name(), moduleId, ctx.getTenantName(), ctx.getTenantId());
+    return new EntitlementEvent(type.name(), moduleId, ctx.getTenantName(), ctx.getTenantId(), ctx.getApplicationId());
   }
 }

--- a/src/main/java/org/folio/entitlement/integration/kafka/model/EntitlementEvent.java
+++ b/src/main/java/org/folio/entitlement/integration/kafka/model/EntitlementEvent.java
@@ -14,4 +14,9 @@ public class EntitlementEvent {
   private String moduleId;
   private String tenantName;
   private UUID tenantId;
+  private String applicationId;
+
+  public EntitlementEvent(String type, String moduleId, String tenantName, UUID tenantId) {
+    this(type, moduleId, tenantName, tenantId, null);
+  }
 }

--- a/src/main/java/org/folio/entitlement/integration/okapi/stage/OkapiModulesEventPublisher.java
+++ b/src/main/java/org/folio/entitlement/integration/okapi/stage/OkapiModulesEventPublisher.java
@@ -16,9 +16,10 @@ public class OkapiModulesEventPublisher extends DatabaseLoggingStage<OkapiStageC
     var tenantName = context.getTenantName();
     var tenantId = context.getTenantId();
     var requestType = context.getEntitlementType().name();
+    var applicationId = context.getApplicationId();
 
     for (var module : context.getModuleDescriptors()) {
-      var event = new EntitlementEvent(requestType, module.getId(), tenantName, tenantId);
+      var event = new EntitlementEvent(requestType, module.getId(), tenantName, tenantId, applicationId);
       entitlementEventPublisher.publish(event);
     }
   }

--- a/src/test/java/org/folio/entitlement/integration/folio/FolioModuleEventPublisherTest.java
+++ b/src/test/java/org/folio/entitlement/integration/folio/FolioModuleEventPublisherTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.Map;
 import java.util.UUID;
-import org.mockito.ArgumentCaptor;
 import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.entitlement.domain.dto.EntitlementType;
 import org.folio.entitlement.domain.model.EntitlementRequest;
@@ -34,6 +33,7 @@ import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/src/test/java/org/folio/entitlement/integration/folio/FolioModuleEventPublisherTest.java
+++ b/src/test/java/org/folio/entitlement/integration/folio/FolioModuleEventPublisherTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.folio.entitlement.domain.dto.EntitlementRequestType.ENTITLE;
 import static org.folio.entitlement.domain.dto.EntitlementRequestType.REVOKE;
 import static org.folio.entitlement.domain.dto.EntitlementRequestType.UPGRADE;
+import static org.folio.entitlement.domain.model.ApplicationStageContext.PARAM_APPLICATION_ID;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_REQUEST;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_TENANT_NAME;
 import static org.folio.entitlement.domain.model.ModuleStageContext.PARAM_INSTALLED_MODULE_DESCRIPTOR;
@@ -22,6 +23,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.Map;
 import java.util.UUID;
+import org.mockito.ArgumentCaptor;
 import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.entitlement.domain.dto.EntitlementType;
 import org.folio.entitlement.domain.model.EntitlementRequest;
@@ -175,5 +177,27 @@ class FolioModuleEventPublisherTest {
     var stageContext = moduleStageContext(FLOW_ID, flowParameters, emptyMap());
     var result = folioModuleEventPublisher.getStageName(stageContext);
     assertThat(result).isEqualTo(MODULE_ID + "-folioModuleEventPublisher");
+  }
+
+  @Test
+  void execute_publishesEventWithApplicationId() {
+    var tenantId = randomUUID();
+    var tenantName = "tenantName";
+    var applicationId = "app-platform-minimal-2.0.53";
+    var request = EntitlementRequest.builder().type(ENTITLE).tenantId(tenantId).build();
+    var desc = new ModuleDescriptor().id(MODULE_ID);
+    var flowParameters = Map.of(
+      PARAM_REQUEST, request,
+      PARAM_MODULE_ENTITLEMENT_TYPE, EntitlementType.ENTITLE,
+      PARAM_MODULE_ID, MODULE_ID,
+      PARAM_MODULE_DESCRIPTOR, desc,
+      PARAM_APPLICATION_ID, applicationId);
+    var stageContext = moduleStageContext(FLOW_ID, flowParameters, Map.of(PARAM_TENANT_NAME, tenantName));
+
+    folioModuleEventPublisher.execute(stageContext);
+
+    var captor = ArgumentCaptor.forClass(EntitlementEvent.class);
+    verify(entitlementEventPublisher).publish(captor.capture());
+    assertThat(captor.getValue().getApplicationId()).isEqualTo(applicationId);
   }
 }

--- a/src/test/java/org/folio/entitlement/integration/okapi/stage/OkapiModulesEventPublisherTest.java
+++ b/src/test/java/org/folio/entitlement/integration/okapi/stage/OkapiModulesEventPublisherTest.java
@@ -1,6 +1,8 @@
 package org.folio.entitlement.integration.okapi.stage;
 
 import static org.folio.entitlement.domain.dto.EntitlementRequestType.ENTITLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.entitlement.domain.model.ApplicationStageContext.PARAM_APPLICATION_ID;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_REQUEST;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_TENANT_NAME;
 import static org.folio.entitlement.integration.okapi.model.OkapiStageContext.PARAM_MODULE_DESCRIPTORS;
@@ -10,11 +12,14 @@ import static org.folio.entitlement.support.TestConstants.TENANT_ID;
 import static org.folio.entitlement.support.TestConstants.TENANT_NAME;
 import static org.folio.entitlement.support.TestValues.entitlementEvent;
 import static org.folio.entitlement.support.TestValues.okapiStageContext;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Map;
 import org.folio.common.domain.model.ModuleDescriptor;
+import org.folio.entitlement.integration.kafka.model.EntitlementEvent;
+import org.mockito.ArgumentCaptor;
 import org.folio.entitlement.domain.dto.EntitlementType;
 import org.folio.entitlement.domain.model.EntitlementRequest;
 import org.folio.entitlement.integration.kafka.EntitlementEventPublisher;
@@ -53,5 +58,26 @@ class OkapiModulesEventPublisherTest {
 
     verify(entitlementEventPublisher).publish(
       entitlementEvent(EntitlementType.ENTITLE, moduleId, TENANT_NAME, TENANT_ID));
+  }
+
+  @Test
+  void execute_publishesEventsWithApplicationId() {
+    var moduleId = "mod-bar-2.0.0";
+    var applicationId = "app-platform-complete-1.2.0";
+    var contextData = Map.of(PARAM_TENANT_NAME, TENANT_NAME);
+    var flowParameters = Map.of(
+      PARAM_REQUEST, EntitlementRequest.builder().type(ENTITLE).tenantId(TENANT_ID).build(),
+      PARAM_MODULE_ENTITLEMENT_TYPE, EntitlementType.ENTITLE,
+      PARAM_MODULE_DESCRIPTORS, List.of(new ModuleDescriptor().id(moduleId)),
+      PARAM_APPLICATION_ID, applicationId);
+    var stageContext = okapiStageContext(FLOW_STAGE_ID, flowParameters, contextData);
+
+    eventPublisher.execute(stageContext);
+
+    var captor = ArgumentCaptor.forClass(EntitlementEvent.class);
+    verify(entitlementEventPublisher, atLeastOnce()).publish(captor.capture());
+    assertThat(captor.getAllValues())
+      .extracting(EntitlementEvent::getApplicationId)
+      .containsOnly(applicationId);
   }
 }

--- a/src/test/java/org/folio/entitlement/integration/okapi/stage/OkapiModulesEventPublisherTest.java
+++ b/src/test/java/org/folio/entitlement/integration/okapi/stage/OkapiModulesEventPublisherTest.java
@@ -1,7 +1,7 @@
 package org.folio.entitlement.integration.okapi.stage;
 
-import static org.folio.entitlement.domain.dto.EntitlementRequestType.ENTITLE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.entitlement.domain.dto.EntitlementRequestType.ENTITLE;
 import static org.folio.entitlement.domain.model.ApplicationStageContext.PARAM_APPLICATION_ID;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_REQUEST;
 import static org.folio.entitlement.domain.model.CommonStageContext.PARAM_TENANT_NAME;
@@ -18,16 +18,16 @@ import static org.mockito.Mockito.verify;
 import java.util.List;
 import java.util.Map;
 import org.folio.common.domain.model.ModuleDescriptor;
-import org.folio.entitlement.integration.kafka.model.EntitlementEvent;
-import org.mockito.ArgumentCaptor;
 import org.folio.entitlement.domain.dto.EntitlementType;
 import org.folio.entitlement.domain.model.EntitlementRequest;
 import org.folio.entitlement.integration.kafka.EntitlementEventPublisher;
+import org.folio.entitlement.integration.kafka.model.EntitlementEvent;
 import org.folio.entitlement.support.TestUtils;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/src/test/java/org/folio/entitlement/it/AbstractFolioEntitlementIT.java
+++ b/src/test/java/org/folio/entitlement/it/AbstractFolioEntitlementIT.java
@@ -8,6 +8,7 @@ import static org.folio.entitlement.support.DesiredStateTestValues.capabilityEve
 import static org.folio.entitlement.support.DesiredStateTestValues.entitlementEventsAfterComplexState;
 import static org.folio.entitlement.support.DesiredStateTestValues.kcResourcesAfterComplexState;
 import static org.folio.entitlement.support.KafkaEventAssertions.assertCapabilityEvents;
+import static org.folio.entitlement.support.KafkaEventAssertions.assertEntitlementEventApplicationIds;
 import static org.folio.entitlement.support.KafkaEventAssertions.assertEntitlementEvents;
 import static org.folio.entitlement.support.KafkaEventAssertions.assertScheduledJobEvents;
 import static org.folio.entitlement.support.KafkaEventAssertions.assertSystemUserEvents;
@@ -138,6 +139,7 @@ abstract class AbstractFolioEntitlementIT extends BaseIntegrationTest {
     assertEntitlementsWithModules(queryByTenantAndAppId(FOLIO_APP1_ID), expected);
     assertModuleEntitlements(FOLIO_MODULE1_ID, expectedModuleEntitlements);
     assertEntitlementEvents(entitlementEvent(ENTITLE, FOLIO_MODULE1_ID));
+    assertEntitlementEventApplicationIds(FOLIO_APP1_ID);
     assertThat(kcClient.getAuthorizationScopes(TENANT_NAME)).containsExactlyElementsOf(ALL_HTTP_METHODS);
     assertThat(kcClient.getAuthorizationResources(TENANT_NAME)).containsExactly(
       authResource("/folio-module1/events", "GET", "POST"), authResource("/folio-module1/events/{id}", "GET"));

--- a/src/test/java/org/folio/entitlement/support/KafkaEventAssertions.java
+++ b/src/test/java/org/folio/entitlement/support/KafkaEventAssertions.java
@@ -41,7 +41,17 @@ public final class KafkaEventAssertions {
     await().untilAsserted(() -> {
       var consumerRecords = getEvents(entitlementTopic(), EntitlementEvent.class);
       var entitlementEvents = mapItems(consumerRecords, ConsumerRecord::value);
-      assertThat(entitlementEvents).containsAll(events);
+      assertThat(entitlementEvents)
+        .usingElementComparatorIgnoringFields("applicationId")
+        .containsAll(events);
+    });
+  }
+
+  public static void assertEntitlementEventApplicationIds(String... expectedApplicationIds) {
+    await().untilAsserted(() -> {
+      var consumerRecords = getEvents(entitlementTopic(), EntitlementEvent.class);
+      var applicationIds = mapItems(consumerRecords, r -> r.value().getApplicationId());
+      assertThat(applicationIds).contains(expectedApplicationIds);
     });
   }
 


### PR DESCRIPTION
## EUREKASUP-156: Multi-version module deployment – propagate applicationId in entitlement events

### Purpose

The Kafka `EntitlementEvent` lacked an `applicationId` field, so downstream consumers (e.g. the sidecar) could not identify which application a module was entitled under. Without this information the sidecar cannot build per-application egress routing tables, which is required to correctly resolve module versions in a multi-application cluster.

US: [EUREKASUP-156](https://folio-org.atlassian.net/browse/EUREKASUP-156)

### Approach

Added `applicationId` to `EntitlementEvent` and updated both the Folio and Okapi event publishers to populate it from the entitlement stage context. A backward-compatible 4-argument constructor is retained so existing call sites without an `applicationId` continue to compile and function.

**Implementation details:**

- Added `applicationId` field to `EntitlementEvent` with a 4-argument legacy constructor (`type`, `moduleId`, `tenantName`, `tenantId`) delegating to the new 5-argument all-args constructor with `applicationId = null`.
- Changed `FolioModuleEventPublisher.getEntitlementEvent` to pass `ctx.getApplicationId()` as the fifth argument.
- Changed `OkapiModulesEventPublisher.execute` to read `context.getApplicationId()` once and pass it to each emitted `EntitlementEvent`.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [x] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.