### PR TITLE
APPPOCTOOL-37: Switch Kong integration test container to folioci/folio-kong image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Version `v4.1.0` (In Progress)
 * Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenant-entitlements (MGRENTITLE-180)
+* Switch Kong integration test container to folioci/folio-kong image (APPPOCTOOL-37)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
   * [How purge flag is working for application uninstalling?](#how-purge-flag-is-working-for-application-uninstalling)
   * [Is rollbacks are supported for the application uninstalling/upgrades?](#is-rollbacks-are-supported-for-the-application-uninstallingupgrades)
   * [How async flag works?](#how-async-flag-works)
+* [Integration Testing](#integration-testing)
 
 ## Introduction
 
@@ -441,6 +442,18 @@ _The Async flag returns the flow identifier instantly, allowing the user to trac
 uninstallation, or upgrading the application using the `/entitlement-flow/{id}` endpoint. If this flag is set
 to `false` - `mgr-tenant-entitlement` holds the response until the entitlement flow is executed, however, the
 flow execution implementation is the same as calling the entitlement process using `async=true`._
+
+## Integration Testing
+
+Integration tests use Testcontainers for PostgreSQL and Kong. The following environment variables
+let you redirect containers to a private registry or adjust startup behaviour without changing
+source code.
+
+| Environment variable                     | Default                         | Description                          |
+|:-----------------------------------------|:--------------------------------|:-------------------------------------|
+| `TESTCONTAINERS_POSTGRES_IMAGE`          | `postgres:16-alpine`            | PostgreSQL container image           |
+| `TESTCONTAINERS_KONG_IMAGE`              | `folioci/folio-kong:latest`     | Kong container image                 |
+| `TESTCONTAINERS_KONG_READINESS_TIMEOUT`  | `120`                           | Seconds to wait for Kong startup     |
 
 ## AI Documentation
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/folio-org/mgr-tenant-entitlements)

--- a/src/test/java/org/folio/entitlement/support/extensions/impl/KongGatewayExtension.java
+++ b/src/test/java/org/folio/entitlement/support/extensions/impl/KongGatewayExtension.java
@@ -3,11 +3,12 @@ package org.folio.entitlement.support.extensions.impl;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static java.time.Duration.ofSeconds;
 import static org.folio.entitlement.support.extensions.impl.PostgresContainerExtension.POSTGRES_NETWORK_ALIAS;
+import static org.folio.test.extensions.impl.DockerImageRegistry.getKongImageName;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.net.URI;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.folio.entitlement.support.extensions.EnableKongGateway;
@@ -18,29 +19,31 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
 
   public static final String KONG_GATEWAY_URL_PROPERTY = "kong.gateway.url";
-  public static final String KONG_DOCKER_IMAGE = "kong:3.7.1-ubuntu";
   public static final String KONG_URL_PROPERTY = "kong.url";
 
-  @SuppressWarnings("resource")
-  private static final GenericContainer<?> CONTAINER = new GenericContainer<>(KONG_DOCKER_IMAGE)
-    .withEnv(kongEnvironment())
-    .withNetwork(Network.SHARED)
-    .withExposedPorts(8000, 8001)
-    .withAccessToHost(true)
-    .withNetworkAliases("kong");
+  private static final String ENV_KONG_READINESS_TIMEOUT = "TESTCONTAINERS_KONG_READINESS_TIMEOUT";
+  private static final long DEFAULT_CONTAINER_READINESS_TIMEOUT = 120;
+
+  private static final long CONTAINER_READINESS_TIMEOUT;
+  private static final GenericContainer<?> CONTAINER;
+
+  static {
+    var env = System.getenv();
+    CONTAINER_READINESS_TIMEOUT = Long.parseLong(
+      env.getOrDefault(ENV_KONG_READINESS_TIMEOUT, String.valueOf(DEFAULT_CONTAINER_READINESS_TIMEOUT)));
+    CONTAINER = kongContainer(getKongImageName());
+  }
 
   private static WireMock wireMockClient;
 
   @Override
   public void beforeAll(ExtensionContext extensionContext) {
     if (!CONTAINER.isRunning()) {
-      runMigrationWithContainer("kong migrations bootstrap");
-      runMigrationWithContainer("kong migrations up && kong migrations finish");
       CONTAINER.start();
     }
 
@@ -56,7 +59,7 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
   }
 
   @Override
-  public void beforeEach(ExtensionContext extensionContext) throws Exception {
+  public void beforeEach(ExtensionContext extensionContext) {
     var enableWiremock = isWireMockEnabled(extensionContext);
     if (enableWiremock) {
       wireMockClient.removeMappings();
@@ -76,24 +79,21 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     return String.format("http://%s:%s", CONTAINER.getHost(), CONTAINER.getMappedPort(port));
   }
 
-  private static void runMigrationWithContainer(String command) {
-    try (var bootstrapMigrations = migrationContainer(command)) {
-      bootstrapMigrations.start();
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to run kong migrations", e);
-    }
-  }
-
   @SuppressWarnings("resource")
-  private static GenericContainer<?> migrationContainer(String command) {
-    return new GenericContainer<>(KONG_DOCKER_IMAGE)
-      .withEnv(kongMigrationEnvironment())
-      .withCommand(command)
+  private static GenericContainer<?> kongContainer(String imageName) {
+    return new GenericContainer<>(imageName)
+      .withEnv(kongEnvironment())
       .withNetwork(Network.SHARED)
-      .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(ofSeconds(30)));
+      .withExposedPorts(8000, 8001)
+      .withAccessToHost(true)
+      .withNetworkAliases("kong")
+      .waitingFor(Wait.forHttp("/status")
+        .forPort(8001)
+        .forStatusCode(200)
+        .withStartupTimeout(Duration.ofSeconds(CONTAINER_READINESS_TIMEOUT)));
   }
 
-  private static Map<String, String> kongMigrationEnvironment() {
+  private static Map<String, String> kongEnvironment() {
     var environment = new LinkedHashMap<String, String>();
 
     environment.put("KONG_DATABASE", "postgres");
@@ -102,16 +102,6 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     environment.put("KONG_PG_PASSWORD", "kong123");
     environment.put("KONG_PG_PORT", "5432");
     environment.put("KONG_PG_HOST", POSTGRES_NETWORK_ALIAS);
-    environment.put("KONG_ROUTER_FLAVOR", "expressions");
-
-    return environment;
-  }
-
-  private static Map<String, String> kongEnvironment() {
-    var environment = new LinkedHashMap<>(kongMigrationEnvironment());
-
-    environment.put("KONG_PROXY_ACCESS_LOG", "/dev/stdout");
-    environment.put("KONG_ADMIN_ACCESS_LOG", "/dev/stdout");
     environment.put("KONG_PROXY_ERROR_LOG", "/dev/stderr");
     environment.put("KONG_ADMIN_ERROR_LOG", "/dev/stderr");
     environment.put("KONG_PROXY_LISTEN", "0.0.0.0:8000");

--- a/src/test/java/org/folio/entitlement/support/extensions/impl/PostgresContainerExtension.java
+++ b/src/test/java/org/folio/entitlement/support/extensions/impl/PostgresContainerExtension.java
@@ -1,6 +1,7 @@
 package org.folio.entitlement.support.extensions.impl;
 
 import static java.lang.String.valueOf;
+import static org.folio.test.extensions.impl.DockerImageRegistry.getPostgresImageName;
 
 import java.util.UUID;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -16,7 +17,7 @@ public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCa
   private static final String DB_PORT_PROPERTY = "DB_PORT";
 
   @SuppressWarnings("resource")
-  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>("postgres:16-alpine")
+  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>(getPostgresImageName())
     .withDatabaseName("postgres")
     .withEnv("PG_USER", "postgres")
     .withUsername("postgres")


### PR DESCRIPTION
### Purpose

The vanilla `kong:3.7.1-ubuntu` image requires the application to spin up ephemeral migration containers before Kong starts, and several Kong configuration env vars must be set explicitly. Switching to `folioci/folio-kong:latest` eliminates that overhead: migrations run automatically inside the image's entrypoint, and router flavour, access log format, and the `auth-headers-manager` plugin are baked in.

US: [APPPOCTOOL-37](https://folio-org.atlassian.net/browse/APPPOCTOOL-37)

### Approach

Switched the Kong test container to the FOLIO-specific `folioci/folio-kong` image, which runs database migrations automatically and bakes in router configuration and access log settings. Both the Kong and Postgres images are now sourced from a central registry, making them overridable via environment variables.

- Switched the Kong container to `folioci/folio-kong:latest` (was `kong:3.7.1-ubuntu`), overridable via the `TESTCONTAINERS_KONG_IMAGE` environment variable.
- Removed the two migration containers that previously ran before Kong started — the folio-kong image handles this internally. The database credentials previously kept in a separate migration environment map were merged into the main environment setup.
- Added an HTTP health check on the Kong admin status endpoint with a configurable startup timeout (120 s by default, overridable via `TESTCONTAINERS_KONG_READINESS_TIMEOUT`).
- Switched the Postgres container image to the central registry, making it overridable via `TESTCONTAINERS_POSTGRES_IMAGE`.

### Dependencies

> Requires [folio-org/applications-poc-tools#339](https://github.com/folio-org/applications-poc-tools/pull/339) to be merged and the updated `folio-backend-testing` artifact to be published before this PR can be merged.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.