### PR TITLE
APPPOCTOOL-37: Fix Kong container readiness check for folioci/folio-kong two-phase startup

### DIFF
--- a/src/test/java/org/folio/entitlement/support/extensions/impl/KongGatewayExtension.java
+++ b/src/test/java/org/folio/entitlement/support/extensions/impl/KongGatewayExtension.java
@@ -3,14 +3,19 @@ package org.folio.entitlement.support.extensions.impl;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.folio.entitlement.support.extensions.impl.PostgresContainerExtension.POSTGRES_NETWORK_ALIAS;
 import static org.folio.test.extensions.impl.DockerImageRegistry.getKongImageName;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.folio.entitlement.support.extensions.EnableKongGateway;
 import org.folio.test.extensions.impl.WireMockExtension;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -28,6 +33,9 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
 
   private static final String ENV_KONG_READINESS_TIMEOUT = "TESTCONTAINERS_KONG_READINESS_TIMEOUT";
   private static final long DEFAULT_CONTAINER_READINESS_TIMEOUT = 120;
+  // folioci/folio-kong runs migrations, starts Kong temporarily for deck sync, stops Kong,
+  // then restarts as the final foreground process. This log line appears just before the stop.
+  private static final String KONG_INIT_DONE_LOG = ".*Kong initialization finished successfully!.*\n";
 
   private static final long CONTAINER_READINESS_TIMEOUT;
   private static final GenericContainer<?> CONTAINER;
@@ -45,6 +53,7 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
   public void beforeAll(ExtensionContext extensionContext) {
     if (!CONTAINER.isRunning()) {
       CONTAINER.start();
+      waitForKongFinalReady();
     }
 
     var enableWiremock = isWireMockEnabled(extensionContext);
@@ -75,6 +84,38 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     System.clearProperty(KONG_GATEWAY_URL_PROPERTY);
   }
 
+  // Waits for the stop+restart cycle that folioci/folio-kong performs after deck sync.
+  // CONTAINER.start() returns when the init-done log line fires; Kong then briefly stops before
+  // coming back as the foreground process. We poll until we observe unavailable?available.
+  private static void waitForKongFinalReady() {
+    var wasUnavailable = new AtomicBoolean(false);
+    await()
+      .pollInterval(200, MILLISECONDS)
+      .atMost(30, SECONDS)
+      .until(() -> {
+        var available = CONTAINER.isRunning() && isKongStatusOk();
+        if (!available) {
+          wasUnavailable.set(true);
+        }
+        return available && wasUnavailable.get();
+      });
+  }
+
+  private static boolean isKongStatusOk() {
+    try {
+      var url = URI.create(getUrlForExposedPort(8001) + "/status").toURL();
+      var connection = (HttpURLConnection) url.openConnection();
+      connection.setConnectTimeout(500);
+      connection.setReadTimeout(500);
+      connection.setRequestMethod("GET");
+      var responseCode = connection.getResponseCode();
+      connection.disconnect();
+      return responseCode == 200;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
   private static String getUrlForExposedPort(int port) {
     return String.format("http://%s:%s", CONTAINER.getHost(), CONTAINER.getMappedPort(port));
   }
@@ -87,9 +128,7 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
       .withExposedPorts(8000, 8001)
       .withAccessToHost(true)
       .withNetworkAliases("kong")
-      .waitingFor(Wait.forHttp("/status")
-        .forPort(8001)
-        .forStatusCode(200)
+      .waitingFor(Wait.forLogMessage(KONG_INIT_DONE_LOG, 1)
         .withStartupTimeout(Duration.ofSeconds(CONTAINER_READINESS_TIMEOUT)));
   }
 


### PR DESCRIPTION
### Purpose

The `folioci/folio-kong` image performs a two-phase startup: it starts Kong temporarily to run `deck sync`, then stops it and restarts as the final foreground process. The previous `Wait.forHttp("/status")` strategy fired after the initial start — before the restart cycle completed — causing integration tests that call Kong's Admin API to fail with `Unexpected end of file from server`.

US: [APPPOCTOOL-37](https://folio-org.atlassian.net/browse/APPPOCTOOL-37)

### Approach

`KongGatewayExtension` used `Wait.forHttp("/status")` to detect when Kong was ready, but that check passes too early with `folioci/folio-kong` — the image starts Kong, syncs routes via `deck`, then briefly shuts it down before the real foreground process begins. By the time tests run, Kong can be mid-restart and unreachable.

The fix has two parts: wait for the right log line before considering startup "done", then actively poll until Kong goes down and comes back up, confirming the restart cycle is fully complete.

- Changed the container wait strategy from an HTTP health check to `Wait.forLogMessage` on `"Kong initialization finished successfully!"` — this line appears after `deck sync` completes, just before the stop+restart cycle, so `CONTAINER.start()` no longer returns prematurely.
- Added `waitForKongFinalReady()` which polls Kong's `/status` endpoint every 200 ms using Awaitility, waiting until it first sees a failure (Kong going down) and then a success (Kong back up) — guaranteeing the final process is the one responding.
- Added `isKongStatusOk()` as a lightweight HTTP probe with 500 ms timeouts that returns `false` on any exception, so transient connection errors during the restart window are treated as "not yet ready" rather than test failures.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.