### PR TITLE
MGRENTITLE-192: Include the full module ID in system-user Kafka events for downstream entitlement processing tracking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
   mod-authtoken security mode is no longer reachable. The `okapi.proxy.tenants.install.post`
   subPermissions were dropped from the module descriptor (MGRENTITLE-111)
 * Remove the application count limit from reinstall endpoint (MGRENTITLE-172)
+* Include the full module ID in system-user Kafka events for downstream entitlement processing tracking (MGRENTITLE-192)
 
 ---
 

--- a/src/main/java/org/folio/entitlement/integration/kafka/model/SystemUserEvent.java
+++ b/src/main/java/org/folio/entitlement/integration/kafka/model/SystemUserEvent.java
@@ -10,6 +10,7 @@ import lombok.Data;
 @AllArgsConstructor(staticName = "of")
 public class SystemUserEvent {
 
+  private String moduleId;
   private String name;
   private String type;
   private List<String> permissions;

--- a/src/main/java/org/folio/entitlement/utils/SystemUserEventProvider.java
+++ b/src/main/java/org/folio/entitlement/utils/SystemUserEventProvider.java
@@ -30,7 +30,7 @@ public class SystemUserEventProvider {
 
   private static SystemUserEvent getSystemUserEvent(ModuleDescriptor moduleDescriptor, UserDescriptor systemUser) {
     var moduleName = SemverUtils.getName(moduleDescriptor.getId());
-    return SystemUserEvent.of(moduleName, systemUser.getType(), systemUser.getPermissions());
+    return SystemUserEvent.of(moduleDescriptor.getId(), moduleName, systemUser.getType(), systemUser.getPermissions());
   }
 
   public Optional<UserDescriptor> findSystemUser(ModuleDescriptor moduleDescriptor) {

--- a/src/test/java/org/folio/entitlement/integration/kafka/SystemUserModuleEventPublisherTest.java
+++ b/src/test/java/org/folio/entitlement/integration/kafka/SystemUserModuleEventPublisherTest.java
@@ -85,7 +85,7 @@ class SystemUserModuleEventPublisherTest {
     var flowParameters = moduleFlowParameters(request, moduleDescriptor);
     var contextData = Map.of(PARAM_TENANT_NAME, TENANT_NAME);
 
-    var systemUserEvent = SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.entities.post"));
+    var systemUserEvent = systemUserEvent(MODULE_ID, MODULE_NAME, List.of("foo.entities.post"));
     when(systemUserEventProvider.getSystemUserEvent(moduleDescriptor)).thenReturn(of(systemUserEvent));
     when(systemUserEventProvider.getSystemUserEvent(null)).thenReturn(empty());
     when(tenantEntitlementKafkaProperties.isProducerTenantCollection()).thenReturn(false);
@@ -105,7 +105,7 @@ class SystemUserModuleEventPublisherTest {
     var flowParameters = moduleFlowParameters(request, moduleDescriptor);
     var contextData = Map.of(PARAM_TENANT_NAME, TENANT_NAME);
 
-    var systemUserEvent = SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.entities.post"));
+    var systemUserEvent = systemUserEvent(MODULE_ID, MODULE_NAME, List.of("foo.entities.post"));
     when(systemUserEventProvider.getSystemUserEvent(moduleDescriptor)).thenReturn(of(systemUserEvent));
     when(systemUserEventProvider.getSystemUserEvent(null)).thenReturn(empty());
     when(tenantEntitlementKafkaProperties.isProducerTenantCollection()).thenReturn(true);
@@ -145,8 +145,8 @@ class SystemUserModuleEventPublisherTest {
       PARAM_APPLICATION_ID, APPLICATION_ID,
       PARAM_ENTITLED_APPLICATION_ID, ENTITLED_APPLICATION_ID,
       PARAM_APPLICATION_FLOW_ID, APPLICATION_FLOW_ID);
-    var v1UserEvent = SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.entities.post"));
-    var v2UserEvent = SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.v2.entities.post"));
+    var v1UserEvent = systemUserEvent(MODULE_ID, MODULE_NAME, List.of("foo.entities.post"));
+    var v2UserEvent = systemUserEvent(MODULE_ID_V2, MODULE_NAME, List.of("foo.v2.entities.post"));
 
     when(systemUserEventProvider.getSystemUserEvent(v1ModuleDescriptor)).thenReturn(of(v1UserEvent));
     when(systemUserEventProvider.getSystemUserEvent(v2ModuleDescriptor)).thenReturn(of(v2UserEvent));
@@ -157,8 +157,8 @@ class SystemUserModuleEventPublisherTest {
 
     var expectedResourceEvent = ResourceEvent.<SystemUserEvent>baseBuilder()
       .type(UPDATE).tenant(TENANT_NAME).resourceName("System user")
-      .newValue(SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.v2.entities.post")))
-      .oldValue(SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.entities.post")))
+      .newValue(systemUserEvent(MODULE_ID_V2, MODULE_NAME, List.of("foo.v2.entities.post")))
+      .oldValue(systemUserEvent(MODULE_ID, MODULE_NAME, List.of("foo.entities.post")))
       .build();
 
     verify(kafkaEventPublisher).send(systemUserTenantTopic(), TENANT_NAME,
@@ -191,7 +191,7 @@ class SystemUserModuleEventPublisherTest {
       PARAM_ENTITLED_APPLICATION_ID, ENTITLED_APPLICATION_ID,
       PARAM_APPLICATION_FLOW_ID, APPLICATION_FLOW_ID);
 
-    var systemUserEvent = SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.entities.post"));
+    var systemUserEvent = systemUserEvent(MODULE_ID, MODULE_NAME, List.of("foo.entities.post"));
     when(systemUserEventProvider.getSystemUserEvent(moduleDescriptor)).thenReturn(of(systemUserEvent));
     when(systemUserEventProvider.getSystemUserEvent(null)).thenReturn(empty());
     when(tenantEntitlementKafkaProperties.isProducerTenantCollection()).thenReturn(false);
@@ -201,7 +201,7 @@ class SystemUserModuleEventPublisherTest {
 
     var expectedResourceEvent = ResourceEvent.<SystemUserEvent>baseBuilder()
       .type(DELETE).tenant(TENANT_NAME).resourceName("System user")
-      .oldValue(SystemUserEvent.of(MODULE_NAME, SYS_USER_TYPE, List.of("foo.entities.post")))
+      .oldValue(systemUserEvent(MODULE_ID, MODULE_NAME, List.of("foo.entities.post")))
       .build();
 
     verify(kafkaEventPublisher).send(systemUserTenantTopic(), TENANT_NAME,
@@ -237,6 +237,10 @@ class SystemUserModuleEventPublisherTest {
     userDescriptor.setType(SYS_USER_TYPE);
     userDescriptor.setPermissions(List.of(permissions));
     return userDescriptor;
+  }
+
+  private static SystemUserEvent systemUserEvent(String moduleId, String moduleName, List<String> permissions) {
+    return SystemUserEvent.of(moduleId, moduleName, SYS_USER_TYPE, permissions);
   }
 
   private static ResourceEvent<SystemUserEvent> resourceEvent(SystemUserEvent entry) {

--- a/src/test/java/org/folio/entitlement/utils/SystemUserEventProviderTest.java
+++ b/src/test/java/org/folio/entitlement/utils/SystemUserEventProviderTest.java
@@ -44,7 +44,8 @@ class SystemUserEventProviderTest {
     var moduleDescriptor = new ModuleDescriptor().id("test-module-0.0.1").user(userDescriptor);
 
     var result = systemUserEventProvider.getSystemUserEvent(moduleDescriptor);
-    assertThat(result).contains(SystemUserEvent.of("test-module", "module", List.of("test.permission")));
+    assertThat(result).contains(SystemUserEvent.of("test-module-0.0.1", "test-module", "module",
+      List.of("test.permission")));
     verifyNoInteractions(objectMapper);
   }
 
@@ -62,7 +63,8 @@ class SystemUserEventProviderTest {
     var moduleDescriptor = JACKSON3_OBJECT_MAPPER.readValue(moduleDescriptorJson, ModuleDescriptor.class);
     var result = systemUserEventProvider.getSystemUserEvent(moduleDescriptor);
 
-    assertThat(result).contains(SystemUserEvent.of("test-module", "system", List.of("test.permission")));
+    assertThat(result).contains(SystemUserEvent.of("test-module-0.0.1", "test-module", "system",
+      List.of("test.permission")));
     verify(objectMapper).convertValue(anyMap(), eq(UserDescriptor.class));
   }
 

--- a/src/test/resources/json/events/folio-app6/folio-module2/system-user-update.json
+++ b/src/test/resources/json/events/folio-app6/folio-module2/system-user-update.json
@@ -3,6 +3,7 @@
   "tenant": "test",
   "resourceName": "System user",
   "new": {
+    "moduleId": "folio-module2-2.1.0",
     "name": "folio-module2",
     "type": "module",
     "permissions": [
@@ -12,6 +13,7 @@
     ]
   },
   "old": {
+    "moduleId": "folio-module2-2.0.0",
     "name": "folio-module2",
     "type": "module",
     "permissions": [

--- a/src/test/resources/json/events/folio-app6/folio-module2/system-user.json
+++ b/src/test/resources/json/events/folio-app6/folio-module2/system-user.json
@@ -3,6 +3,7 @@
   "tenant": "test",
   "resourceName": "System user",
   "new": {
+    "moduleId": "folio-module2-2.0.0",
     "name": "folio-module2",
     "type": "module",
     "permissions": [

--- a/src/test/resources/json/events/folio-app6/folio-module3/system-user-deprecated.json
+++ b/src/test/resources/json/events/folio-app6/folio-module3/system-user-deprecated.json
@@ -3,6 +3,7 @@
   "tenant": "test",
   "resourceName": "System user",
   "old": {
+    "moduleId": "folio-module3-3.0.0",
     "name": "folio-module3",
     "type": "module",
     "permissions": [

--- a/src/test/resources/json/events/folio-app6/folio-module3/system-user.json
+++ b/src/test/resources/json/events/folio-app6/folio-module3/system-user.json
@@ -3,6 +3,7 @@
   "tenant": "test",
   "resourceName": "System user",
   "new": {
+    "moduleId": "folio-module3-3.0.0",
     "name": "folio-module3",
     "type": "module",
     "permissions": [

--- a/src/test/resources/json/events/folio-app6/folio-module4/system-user.json
+++ b/src/test/resources/json/events/folio-app6/folio-module4/system-user.json
@@ -3,6 +3,7 @@
   "tenant": "test",
   "resourceName": "System user",
   "new": {
+    "moduleId": "folio-module4-4.0.0",
     "name": "folio-module4",
     "type": "module",
     "permissions": [


### PR DESCRIPTION

### **Purpose**
Changes for [MGRENTITLE-192](https://folio-org.atlassian.net/browse/MGRENTITLE-192)

### **Approach**
Added moduleId to MTE system-user Kafka event payloads, populated with the full module descriptor ID while preserving the module name.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
